### PR TITLE
LRCLIB synced lyrics provider

### DIFF
--- a/ACKNOWLEDGEMENTS_AND_PRIVACY.md
+++ b/ACKNOWLEDGEMENTS_AND_PRIVACY.md
@@ -89,6 +89,13 @@ AudioMator only uses the network for optional features that you explicitly invok
 - Typical data sent: lookup terms derived from metadata fields or user input, such as title, artist, album, album artist, track/disc information, duration, UPC/barcode, iTunes Album ID, iTunes Artist ID, iTunes track catalog ID, pasted Apple Music or iTunes links, storefront country, or manually entered search text.
 - Typical data received: album and track metadata, release dates, genres, explicit-content flags, copyright text, Apple/iTunes IDs, candidate artwork metadata, and image files selected for preview or application.
 
+### LRCLIB
+
+- Host: `lrclib.net`
+- Purpose: search and preview candidate synced lyrics for a selected track.
+- Typical data sent: lookup terms derived from metadata fields or filename fallback, such as title, artist, album, and duration.
+- Typical data received: candidate track, artist, album, duration, plain lyrics availability, and synced lyrics text selected for preview or application.
+
 ### Release notes
 
 - Host: `api.github.com`
@@ -113,4 +120,4 @@ AudioMator only uses the network for optional features that you explicitly invok
 
 If you stay inside local editing features, AudioMator stays offline.
 
-If you use MusicBrainz, iTunes metadata/artwork lookup, release-note lookup, or a future software-update flow, only the request information needed for that feature is sent. The audio file contents themselves remain local.
+If you use MusicBrainz, iTunes metadata/artwork lookup, LRCLIB lyrics lookup, release-note lookup, or a future software-update flow, only the request information needed for that feature is sent. The audio file contents themselves remain local.

--- a/AudioMator/App/AudioMatorApp.swift
+++ b/AudioMator/App/AudioMatorApp.swift
@@ -19,6 +19,7 @@ struct AudioMatorApp: App {
     @StateObject private var viewModel: AudioViewModel
     @StateObject private var sharedState: SharedState
     @StateObject private var musicBrainzBrowserStore: MusicBrainzBrowserStore
+    @StateObject private var lrclibLyricsBrowserStore: LRCLIBLyricsBrowserStore
     @StateObject private var metadataFilenameToolStore: MetadataFilenameToolStore
     @StateObject private var metadataEditorStore: MetadataEditorStore
 
@@ -30,6 +31,7 @@ struct AudioMatorApp: App {
         )
         _sharedState = StateObject(wrappedValue: SharedState())
         _musicBrainzBrowserStore = StateObject(wrappedValue: MusicBrainzBrowserStore())
+        _lrclibLyricsBrowserStore = StateObject(wrappedValue: LRCLIBLyricsBrowserStore())
         _metadataFilenameToolStore = StateObject(wrappedValue: MetadataFilenameToolStore())
         _metadataEditorStore = StateObject(
             wrappedValue: MetadataEditorStore(metadataPipeline: metadataPipeline)
@@ -43,6 +45,7 @@ struct AudioMatorApp: App {
                 viewModel: viewModel,
                 state: sharedState,
                 musicBrainzBrowserStore: musicBrainzBrowserStore,
+                lrclibLyricsBrowserStore: lrclibLyricsBrowserStore,
                 metadataFilenameToolStore: metadataFilenameToolStore,
                 metadataEditorStore: metadataEditorStore,
                 metadataPipeline: metadataPipeline
@@ -74,6 +77,7 @@ struct AudioMatorApp: App {
         Window(AppWindowTitle.onlineMetadataKey, id: MusicBrainzBrowserView.windowID) {
             MusicBrainzBrowserView(
                 store: musicBrainzBrowserStore,
+                lrclibStore: lrclibLyricsBrowserStore,
                 viewModel: viewModel
             )
             .audiomatorMacWindowChrome()
@@ -103,6 +107,7 @@ struct AudioMatorApp: App {
                 viewModel: viewModel,
                 state: sharedState,
                 musicBrainzBrowserStore: musicBrainzBrowserStore,
+                lrclibLyricsBrowserStore: lrclibLyricsBrowserStore,
                 metadataFilenameToolStore: metadataFilenameToolStore,
                 metadataEditorStore: metadataEditorStore,
                 metadataPipeline: metadataPipeline

--- a/AudioMator/Core/Network/NetworkServiceDisclosure.swift
+++ b/AudioMator/Core/Network/NetworkServiceDisclosure.swift
@@ -36,6 +36,16 @@ enum NetworkServiceDisclosure {
         }
     }
 
+    enum LRCLIB {
+        static let host = "lrclib.net"
+
+        static let domains = [
+            host
+        ]
+
+        static let sentDataSummary = "LRCLIB lookup may send metadata-derived queries, including title, artist, album, and duration, to search for synced lyrics."
+    }
+
     enum ReleaseNotes {
         static let host = "api.github.com"
     }

--- a/AudioMator/Features/LRCLIBLyricsBrowser/ViewModels/LRCLIBLyricsBrowserStore.swift
+++ b/AudioMator/Features/LRCLIBLyricsBrowser/ViewModels/LRCLIBLyricsBrowserStore.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Combine
+
+enum LRCLIBLyricsSearchState: Equatable {
+    case idle
+    case searching
+    case loaded
+    case cancelled
+    case failed(String)
+}
+
+@MainActor
+final class LRCLIBLyricsBrowserStore: ObservableObject {
+    private struct FileState {
+        var searchState: LRCLIBLyricsSearchState = .idle
+        var rankedCandidates: [LRCLIBRankedCandidate] = []
+        var selectedCandidateID: LRCLIBLyricsCandidate.ID?
+        var appliedCandidateID: LRCLIBLyricsCandidate.ID?
+    }
+
+    @Published private(set) var fileInputs: [LRCLIBFileSearchInput] = []
+    @Published private(set) var currentIndex: Int = 0
+    @Published private(set) var sourceDescription: String = "Select files in AudioMator, then choose LRCLIB."
+    @Published private(set) var navigationResetToken = UUID()
+
+    private let client: any LRCLIBLyricsSearching
+    private var searchTask: Task<Void, Never>?
+    @Published private var statesByFileID: [AudioFile.ID: FileState] = [:]
+
+    init(client: any LRCLIBLyricsSearching = LRCLIBClient()) {
+        self.client = client
+    }
+
+    deinit {
+        searchTask?.cancel()
+    }
+
+    var hasFiles: Bool {
+        !fileInputs.isEmpty
+    }
+
+    var currentFile: LRCLIBFileSearchInput? {
+        guard fileInputs.indices.contains(currentIndex) else { return nil }
+        return fileInputs[currentIndex]
+    }
+
+    var currentQuery: LRCLIBSearchQuery? {
+        currentFile?.query
+    }
+
+    var searchState: LRCLIBLyricsSearchState {
+        guard let currentFile else { return .idle }
+        return statesByFileID[currentFile.id]?.searchState ?? .idle
+    }
+
+    var rankedCandidates: [LRCLIBRankedCandidate] {
+        guard let currentFile else { return [] }
+        return statesByFileID[currentFile.id]?.rankedCandidates ?? []
+    }
+
+    var selectedCandidateID: LRCLIBLyricsCandidate.ID? {
+        guard let currentFile else { return nil }
+        return statesByFileID[currentFile.id]?.selectedCandidateID
+    }
+
+    var selectedCandidate: LRCLIBLyricsCandidate? {
+        guard let selectedCandidateID else { return nil }
+        return rankedCandidates.first { $0.id == selectedCandidateID }?.candidate
+    }
+
+    var appliedCandidateID: LRCLIBLyricsCandidate.ID? {
+        guard let currentFile else { return nil }
+        return statesByFileID[currentFile.id]?.appliedCandidateID
+    }
+
+    var canMovePrevious: Bool {
+        currentIndex > 0
+    }
+
+    var canMoveNext: Bool {
+        currentIndex + 1 < fileInputs.count
+    }
+
+    var queuePositionText: String {
+        guard hasFiles else { return "No files selected" }
+        return "\(currentIndex + 1) of \(fileInputs.count)"
+    }
+
+    var hasSyncedCandidate: Bool {
+        rankedCandidates.contains { $0.candidate.hasSyncedLyrics }
+    }
+
+    var canApplySelectedCandidate: Bool {
+        selectedCandidate?.hasSyncedLyrics == true
+    }
+
+    func seed(from files: [AudioFile]) {
+        searchTask?.cancel()
+        let inputs = files.map(LRCLIBFileSearchInput.init(file:))
+        fileInputs = inputs
+        currentIndex = 0
+        statesByFileID = Dictionary(
+            uniqueKeysWithValues: inputs.map { ($0.id, FileState()) }
+        )
+        sourceDescription = inputs.count == 1
+            ? "From the selected file metadata, filename, and path."
+            : "Reviewing \(inputs.count) selected files one by one."
+        navigationResetToken = UUID()
+    }
+
+    func closeWindowSession() {
+        searchTask?.cancel()
+        fileInputs = []
+        currentIndex = 0
+        statesByFileID = [:]
+        sourceDescription = "Select files in AudioMator, then choose LRCLIB."
+        navigationResetToken = UUID()
+    }
+
+    func searchCurrentFile() {
+        guard let file = currentFile else { return }
+        let query = file.query
+        guard !query.isEmpty else {
+            updateState(for: file.id) { state in
+                state.searchState = .failed(LRCLIBClientError.emptyQuery.localizedDescription)
+                state.rankedCandidates = []
+                state.selectedCandidateID = nil
+            }
+            return
+        }
+
+        searchTask?.cancel()
+        updateState(for: file.id) { state in
+            state.searchState = .searching
+            state.rankedCandidates = []
+            state.selectedCandidateID = nil
+        }
+
+        searchTask = Task { [client] in
+            do {
+                let candidates = try await client.search(matching: query, limit: 20)
+                guard !Task.isCancelled else { return }
+                let rankedCandidates = LRCLIBCandidateRanker.rankedCandidates(candidates, for: query)
+                await MainActor.run {
+                    self.updateState(for: file.id) { state in
+                        state.searchState = .loaded
+                        state.rankedCandidates = rankedCandidates
+                        state.selectedCandidateID = rankedCandidates.first?.id
+                    }
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    self.updateState(for: file.id) { state in
+                        state.searchState = .cancelled
+                    }
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    self.updateState(for: file.id) { state in
+                        state.searchState = .failed((error as? LocalizedError)?.errorDescription ?? error.localizedDescription)
+                        state.rankedCandidates = []
+                        state.selectedCandidateID = nil
+                    }
+                }
+            }
+        }
+    }
+
+    func cancelSearch() {
+        guard searchState == .searching else { return }
+        searchTask?.cancel()
+        if let currentFile {
+            updateState(for: currentFile.id) { state in
+                state.searchState = .cancelled
+            }
+        }
+    }
+
+    func selectCandidate(_ candidateID: LRCLIBLyricsCandidate.ID?) {
+        guard let currentFile else { return }
+        updateState(for: currentFile.id) { state in
+            state.selectedCandidateID = candidateID
+        }
+    }
+
+    func movePrevious() {
+        guard canMovePrevious else { return }
+        searchTask?.cancel()
+        currentIndex -= 1
+        navigationResetToken = UUID()
+    }
+
+    func moveNext() {
+        guard canMoveNext else { return }
+        searchTask?.cancel()
+        currentIndex += 1
+        navigationResetToken = UUID()
+    }
+
+    func markCurrentFileApplied(candidateID: LRCLIBLyricsCandidate.ID) {
+        guard let currentFile else { return }
+        updateState(for: currentFile.id) { state in
+            state.appliedCandidateID = candidateID
+        }
+    }
+
+    private func updateState(
+        for fileID: AudioFile.ID,
+        mutate: (inout FileState) -> Void
+    ) {
+        var state = statesByFileID[fileID] ?? FileState()
+        mutate(&state)
+        statesByFileID[fileID] = state
+    }
+}

--- a/AudioMator/Features/LRCLIBLyricsBrowser/Views/LRCLIBLyricsBrowserView.swift
+++ b/AudioMator/Features/LRCLIBLyricsBrowser/Views/LRCLIBLyricsBrowserView.swift
@@ -1,0 +1,417 @@
+import SwiftUI
+
+struct LRCLIBLyricsBrowserView: View {
+    @ObservedObject var store: LRCLIBLyricsBrowserStore
+    @ObservedObject var viewModel: AudioViewModel
+    let onBackToSources: () -> Void
+
+    @State private var isApplyingLyrics = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(minWidth: 920, minHeight: 620)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(platformColor: .audiomatorWindowBackground))
+        .audiomatorMacTitlebarScrollEdgeBar()
+        .onAppear {
+            if store.hasFiles {
+                store.searchCurrentFile()
+            }
+        }
+        .onChange(of: store.navigationResetToken) { _, _ in
+            if store.hasFiles {
+                store.searchCurrentFile()
+            }
+        }
+        #if os(macOS)
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button {
+                    onBackToSources()
+                } label: {
+                    Label("Sources", systemImage: "chevron.left")
+                }
+            }
+
+            ToolbarItemGroup(placement: .primaryAction) {
+                if store.searchState == .searching {
+                    Button("Cancel") {
+                        store.cancelSearch()
+                    }
+                } else {
+                    Button("Search") {
+                        store.searchCurrentFile()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!store.hasFiles)
+                }
+            }
+        }
+        #endif
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("LRCLIB Lyrics")
+                        .font(.title3.weight(.semibold))
+                    Text(store.sourceDescription)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Text(store.queuePositionText)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(
+                        Capsule(style: .continuous)
+                            .fill(Color.secondary.opacity(0.12))
+                    )
+            }
+
+            if let currentFile = store.currentFile {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(currentFile.displayTitle)
+                        .font(.headline)
+                    Text([currentFile.artist, currentFile.album].filter { !$0.isEmpty }.joined(separator: " · "))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(currentFile.fileName)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 16)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !store.hasFiles {
+            ContentUnavailableView(
+                "No Files Selected",
+                systemImage: "music.note.list",
+                description: Text("Select one or more audio files in AudioMator, then open LRCLIB from Online Metadata.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            HStack(spacing: 0) {
+                resultsPane
+                    .frame(minWidth: 340, idealWidth: 390, maxWidth: 460)
+                Divider()
+                previewPane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    private var resultsPane: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Candidates")
+                    .font(.headline)
+                Spacer()
+                if store.searchState == .loaded {
+                    Text("\(store.rankedCandidates.count)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            resultsStateContent
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var resultsStateContent: some View {
+        switch store.searchState {
+        case .idle:
+            ContentUnavailableView(
+                "Search LRCLIB",
+                systemImage: "text.magnifyingglass",
+                description: Text("Search uses this file's title, artist, album, and duration when available.")
+            )
+        case .searching:
+            VStack(spacing: 10) {
+                Spacer()
+                ProgressView("Searching LRCLIB…")
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .cancelled:
+            ContentUnavailableView(
+                "Search Cancelled",
+                systemImage: "xmark.circle",
+                description: Text("Start a new search when you are ready.")
+            )
+        case .failed(let message):
+            ContentUnavailableView(
+                "Unable to Search LRCLIB",
+                systemImage: "exclamationmark.triangle",
+                description: Text(message)
+            )
+        case .loaded:
+            if store.rankedCandidates.isEmpty {
+                ContentUnavailableView(
+                    "No Results",
+                    systemImage: "text.magnifyingglass",
+                    description: Text("LRCLIB did not return lyrics candidates for this track.")
+                )
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        if !store.hasSyncedCandidate {
+                            Label("No synced lyrics found in these results.", systemImage: "info.circle")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.bottom, 4)
+                        }
+
+                        ForEach(store.rankedCandidates) { rankedCandidate in
+                            LRCLIBCandidateRow(
+                                rankedCandidate: rankedCandidate,
+                                isSelected: store.selectedCandidateID == rankedCandidate.id,
+                                isApplied: store.appliedCandidateID == rankedCandidate.id
+                            ) {
+                                store.selectCandidate(rankedCandidate.id)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+    }
+
+    private var previewPane: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Preview")
+                    .font(.headline)
+
+                Spacer()
+
+                if let candidate = store.selectedCandidate {
+                    Text(candidate.lyricsAvailabilityLabel)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(candidate.hasSyncedLyrics ? Color.green : Color.secondary)
+                }
+            }
+
+            if let candidate = store.selectedCandidate {
+                selectedCandidatePreview(candidate)
+            } else {
+                ContentUnavailableView(
+                    "No Candidate Selected",
+                    systemImage: "text.line.first.and.arrowtriangle.forward",
+                    description: Text("Choose a result to preview the lyrics before applying.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .padding(16)
+    }
+
+    private func selectedCandidatePreview(_ candidate: LRCLIBLyricsCandidate) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            LRCLIBCandidateMetadataView(candidate: candidate)
+
+            if candidate.hasSyncedLyrics, let syncedLyrics = candidate.syncedLyrics {
+                lyricsPreview(text: syncedLyrics)
+            } else if candidate.hasPlainLyrics, let plainLyrics = candidate.plainLyrics {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("This result has plain lyrics only. It will not be applied as synced lyrics.", systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    lyricsPreview(text: plainLyrics)
+                }
+            } else {
+                ContentUnavailableView(
+                    candidate.instrumental ? "Instrumental Result" : "No Lyrics Text",
+                    systemImage: "music.note",
+                    description: Text("Choose another candidate with synced lyrics.")
+                )
+            }
+        }
+    }
+
+    private func lyricsPreview(text: String) -> some View {
+        ScrollView {
+            Text(text)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+        )
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Button {
+                store.movePrevious()
+            } label: {
+                Label("Previous", systemImage: "chevron.left")
+            }
+            .disabled(!store.canMovePrevious || isApplyingLyrics)
+
+            Button {
+                store.moveNext()
+            } label: {
+                Label("Next", systemImage: "chevron.right")
+            }
+            .disabled(!store.canMoveNext || isApplyingLyrics)
+
+            Spacer()
+
+            if isApplyingLyrics {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button("Apply Synced Lyrics") {
+                Task {
+                    await applySelectedLyrics()
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!store.canApplySelectedCandidate || isApplyingLyrics)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    private func applySelectedLyrics() async {
+        guard
+            !isApplyingLyrics,
+            let currentFile = store.currentFile,
+            let candidate = store.selectedCandidate,
+            let syncedLyrics = candidate.syncedLyrics,
+            candidate.hasSyncedLyrics
+        else {
+            return
+        }
+
+        isApplyingLyrics = true
+        let didApply = await viewModel.applyLRCLIBSyncedLyrics(syncedLyrics, to: currentFile.id)
+        if didApply {
+            store.markCurrentFileApplied(candidateID: candidate.id)
+        }
+        isApplyingLyrics = false
+    }
+}
+
+private struct LRCLIBCandidateRow: View {
+    let rankedCandidate: LRCLIBRankedCandidate
+    let isSelected: Bool
+    let isApplied: Bool
+    let onSelect: () -> Void
+
+    private var candidate: LRCLIBLyricsCandidate {
+        rankedCandidate.candidate
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(candidate.trackName.isEmpty ? "Untitled Track" : candidate.trackName)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Text("\(rankedCandidate.score)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+
+                Text([candidate.artistName, candidate.albumName].filter { !$0.isEmpty }.joined(separator: " · "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                HStack(spacing: 8) {
+                    Label(candidate.lyricsAvailabilityLabel, systemImage: candidate.hasSyncedLyrics ? "waveform" : "text.alignleft")
+                        .foregroundStyle(candidate.hasSyncedLyrics ? Color.green : Color.secondary)
+
+                    if let duration = candidate.durationSeconds {
+                        Text(durationLabel(duration))
+                    }
+
+                    if isApplied {
+                        Label("Applied", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                }
+                .font(.caption.weight(.medium))
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.07))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor.opacity(0.55) : Color.secondary.opacity(0.14), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func durationLabel(_ duration: Int) -> String {
+        let minutes = duration / 60
+        let seconds = duration % 60
+        return "\(minutes):\(String(format: "%02d", seconds))"
+    }
+}
+
+private struct LRCLIBCandidateMetadataView: View {
+    let candidate: LRCLIBLyricsCandidate
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(candidate.trackName.isEmpty ? "Untitled Track" : candidate.trackName)
+                .font(.title3.weight(.semibold))
+            Text([candidate.artistName, candidate.albumName].filter { !$0.isEmpty }.joined(separator: " · "))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                Text("LRCLIB ID \(candidate.id)")
+                if let duration = candidate.durationSeconds {
+                    Text("\(duration)s")
+                }
+                if candidate.instrumental {
+                    Text("Instrumental")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/AudioMator/Features/Main/ViewModels/AudioViewModel+MetadataWrite.swift
+++ b/AudioMator/Features/Main/ViewModels/AudioViewModel+MetadataWrite.swift
@@ -573,6 +573,83 @@ extension AudioViewModel {
         presentBatchMetadataWriteSummary(summary)
     }
 
+    func applyLRCLIBSyncedLyrics(_ syncedLyrics: String, to fileID: AudioFile.ID) async -> Bool {
+        guard metadataSaveProgress == nil else { return false }
+        let normalizedLyrics = syncedLyrics.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedLyrics.isEmpty else { return false }
+
+        guard let file = files.first(where: { $0.id == fileID }) else {
+            presentMetadataWriteHUD(
+                style: .failure,
+                title: "Apply Lyrics Failed",
+                subtitle: "The file is no longer loaded in AudioMator."
+            )
+            return false
+        }
+
+        guard isTagWriteSupportedExtension(file.url.pathExtension) else {
+            presentMetadataWriteHUD(
+                style: .failure,
+                title: "Apply Lyrics Failed",
+                subtitle: "This format does not support metadata writing yet."
+            )
+            return false
+        }
+
+        beginMetadataSaveProgress(
+            title: "Applying LRCLIB Lyrics",
+            subtitle: file.url.lastPathComponent,
+            totalUnitCount: 1
+        )
+
+        do {
+            var propertyMap = try await rawMetadataPropertyMapOffMainActor(for: file.url)
+            propertyMap["LYRICS"] = normalizedLyrics
+
+            let writeResult = try await writeRawMetadataPropertyMapOffMainActor(propertyMap, to: file.url)
+            var warnings = writeResult.warnings
+            let refreshWarning = await reloadEditedFile(file, syncInspectorAfterReload: true)
+            if let refreshWarning {
+                warnings.append(refreshWarning)
+            }
+
+            updateMetadataSaveProgress(
+                subtitle: file.url.lastPathComponent,
+                completedUnitCount: 1
+            )
+            endMetadataSaveProgress()
+
+            if warnings.isEmpty {
+                presentMetadataWriteHUD(
+                    style: .success,
+                    title: "LRCLIB Lyrics Applied",
+                    subtitle: file.url.lastPathComponent
+                )
+            } else {
+                presentMetadataWriteWarning(
+                    title: "Lyrics Applied with Issues",
+                    subtitle: ([file.url.lastPathComponent] + warnings).joined(separator: "\n")
+                )
+            }
+
+            return true
+        } catch {
+            updateMetadataSaveProgress(
+                subtitle: file.url.lastPathComponent,
+                completedUnitCount: 1
+            )
+            endMetadataSaveProgress()
+            presentMetadataWriteHUD(
+                style: .failure,
+                title: "Apply Lyrics Failed",
+                subtitle: [file.url.lastPathComponent, (error as NSError).localizedDescription]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n")
+            )
+            return false
+        }
+    }
+
     func applyRawMetadataPropertyMaps(
         _ propertyMaps: [AudioFile.ID: [String: String]],
         to targets: [MetadataEditorTarget]
@@ -943,6 +1020,14 @@ extension AudioViewModel {
 
         return try await Task.detached(priority: .userInitiated) {
             try metadataPipeline.writeMetadata(edit, to: url)
+        }.value
+    }
+
+    private func rawMetadataPropertyMapOffMainActor(for url: URL) async throws -> [String: String] {
+        let metadataPipeline = self.metadataPipeline
+
+        return try await Task.detached(priority: .userInitiated) {
+            try metadataPipeline.rawMetadataPropertyMap(for: url)
         }.value
     }
 

--- a/AudioMator/Features/Main/Views/ContentView.swift
+++ b/AudioMator/Features/Main/Views/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
     @ObservedObject var viewModel: AudioViewModel
     @ObservedObject var state: SharedState
     @ObservedObject var musicBrainzBrowserStore: MusicBrainzBrowserStore
+    @ObservedObject var lrclibLyricsBrowserStore: LRCLIBLyricsBrowserStore
     @ObservedObject var metadataFilenameToolStore: MetadataFilenameToolStore
     @ObservedObject var metadataEditorStore: MetadataEditorStore
     let metadataPipeline: any AudioMetadataPipeline
@@ -111,6 +112,7 @@ struct ContentView: View {
             .sheet(isPresented: $isMusicBrainzBrowserPresented) {
                 MusicBrainzBrowserView(
                     store: musicBrainzBrowserStore,
+                    lrclibStore: lrclibLyricsBrowserStore,
                     viewModel: viewModel
                 )
             }
@@ -265,6 +267,7 @@ struct ContentView: View {
     private func openMusicBrainzBrowser() {
         let seed = currentMusicBrainzMatchSeed() ?? currentMusicBrainzSearchSeed()
         musicBrainzBrowserStore.apply(seed: seed)
+        seedLRCLIBLyricsBrowser()
         #if os(macOS)
         openWindow(id: MusicBrainzBrowserView.windowID)
         #else
@@ -280,6 +283,7 @@ struct ContentView: View {
         guard let seed = currentMusicBrainzMatchSeed() else { return }
 
         musicBrainzBrowserStore.apply(seed: seed)
+        seedLRCLIBLyricsBrowser()
         #if os(macOS)
         openWindow(id: MusicBrainzBrowserView.windowID)
         #else
@@ -501,6 +505,11 @@ struct ContentView: View {
 
     private func musicBrainzFileInputs(from files: [AudioFile]) -> [MusicBrainzFileSearchInput] {
         files.map { MusicBrainzFilenameFallbackResolver.makeSearchInput(for: $0) }
+    }
+
+    private func seedLRCLIBLyricsBrowser() {
+        let selectedFiles = viewModel.files.filter { state.selectedAudioIDs.contains($0.id) }
+        lrclibLyricsBrowserStore.seed(from: selectedFiles)
     }
 
     private func preferredMusicBrainzSeedValue(_ primary: String, fallback: String) -> String {
@@ -804,6 +813,7 @@ struct ContentView_Previews: PreviewProvider {
             viewModel: AudioViewModel(),
             state: SharedState(),
             musicBrainzBrowserStore: MusicBrainzBrowserStore(),
+            lrclibLyricsBrowserStore: LRCLIBLyricsBrowserStore(),
             metadataFilenameToolStore: MetadataFilenameToolStore(),
             metadataEditorStore: MetadataEditorStore(metadataPipeline: TagLibAudioMetadataPipeline()),
             metadataPipeline: TagLibAudioMetadataPipeline()

--- a/AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzBrowserView.swift
+++ b/AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzBrowserView.swift
@@ -4,6 +4,7 @@ struct MusicBrainzBrowserView: View {
     static let windowID = "musicbrainz-browser"
 
     @ObservedObject var store: MusicBrainzBrowserStore
+    @ObservedObject var lrclibStore: LRCLIBLyricsBrowserStore
     @ObservedObject var viewModel: AudioViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var selectedMetadataSource: MetadataBrowserSource?
@@ -18,6 +19,12 @@ struct MusicBrainzBrowserView: View {
                     musicBrainzContent
                 case .iTunes:
                     ITunesBrowserView(
+                        viewModel: viewModel,
+                        onBackToSources: { self.selectedMetadataSource = nil }
+                    )
+                case .lrclib:
+                    LRCLIBLyricsBrowserView(
+                        store: lrclibStore,
                         viewModel: viewModel,
                         onBackToSources: { self.selectedMetadataSource = nil }
                     )
@@ -47,6 +54,7 @@ struct MusicBrainzBrowserView: View {
             selectedMetadataSource = nil
             navigationPath.removeAll()
             store.closeWindowSession()
+            lrclibStore.closeWindowSession()
         }
     }
 
@@ -136,8 +144,11 @@ struct MusicBrainzBrowserView: View {
 
     private func selectMetadataSource(_ source: MetadataBrowserSource) {
         selectedMetadataSource = source
-        if source == .musicBrainz, store.hasSearchText {
+        switch source {
+        case .musicBrainz where store.hasSearchText:
             store.search()
+        default:
+            break
         }
     }
 

--- a/AudioMator/Features/OnlineMetadataBrowser/MetadataBrowserSource.swift
+++ b/AudioMator/Features/OnlineMetadataBrowser/MetadataBrowserSource.swift
@@ -3,6 +3,7 @@ import Foundation
 enum MetadataBrowserSource: String, CaseIterable, Identifiable {
     case musicBrainz
     case iTunes
+    case lrclib
 
     var id: String { rawValue }
 
@@ -10,6 +11,7 @@ enum MetadataBrowserSource: String, CaseIterable, Identifiable {
         switch self {
         case .musicBrainz: return L10n.string("MusicBrainz")
         case .iTunes: return L10n.string("iTunes")
+        case .lrclib: return "LRCLIB"
         }
     }
 
@@ -19,6 +21,8 @@ enum MetadataBrowserSource: String, CaseIterable, Identifiable {
             return L10n.string("Search MusicBrainz metadata, release relationships, credits, and MusicBrainz IDs.")
         case .iTunes:
             return L10n.string("Search iTunes catalog metadata from tags, filenames, UPCs, links, and store IDs.")
+        case .lrclib:
+            return "Search LRCLIB for synced lyrics from the selected track metadata."
         }
     }
 
@@ -26,6 +30,7 @@ enum MetadataBrowserSource: String, CaseIterable, Identifiable {
         switch self {
         case .musicBrainz: return "brain.head.profile"
         case .iTunes: return "music.pages"
+        case .lrclib: return "waveform.and.magnifyingglass"
         }
     }
 }

--- a/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
@@ -402,13 +402,13 @@ private struct NetworkPrivacyPage: View {
                     PrivacyRow(
                         symbol: "text.magnifyingglass",
                         title: "Lookup sends search details",
-                        description: "MusicBrainz and iTunes searches may use metadata such as title, artist, album, track number, duration, identifiers, links, or text you enter."
+                        description: "MusicBrainz, iTunes, and LRCLIB searches may use metadata such as title, artist, album, track number, duration, identifiers, links, or text you enter."
                     )
 
                     PrivacyRow(
                         symbol: "network",
                         title: "External services",
-                        description: "Lookups may contact MusicBrainz, Apple iTunes Search API, Apple artwork CDN, or related services."
+                        description: "Lookups may contact MusicBrainz, Apple iTunes Search API, Apple artwork CDN, LRCLIB, or related services."
                     )
 
                     Text(domainSummary)
@@ -425,7 +425,8 @@ private struct NetworkPrivacyPage: View {
 
     private var domainSummary: String {
         (NetworkServiceDisclosure.MusicBrainz.domains +
-            NetworkServiceDisclosure.ITunesArtwork.domains)
+            NetworkServiceDisclosure.ITunesArtwork.domains +
+            NetworkServiceDisclosure.LRCLIB.domains)
             .joined(separator: "  ")
     }
 }

--- a/AudioMator/Infrastructure/LRCLIB/LRCLIBCandidateRanker.swift
+++ b/AudioMator/Infrastructure/LRCLIB/LRCLIBCandidateRanker.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+struct LRCLIBRankedCandidate: Identifiable, Equatable, Sendable {
+    let candidate: LRCLIBLyricsCandidate
+    let score: Int
+
+    var id: Int { candidate.id }
+}
+
+enum LRCLIBCandidateRanker {
+    static func rankedCandidates(
+        _ candidates: [LRCLIBLyricsCandidate],
+        for query: LRCLIBSearchQuery
+    ) -> [LRCLIBRankedCandidate] {
+        candidates
+            .map { candidate in
+                LRCLIBRankedCandidate(
+                    candidate: candidate,
+                    score: score(candidate: candidate, query: query)
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                if lhs.candidate.hasSyncedLyrics != rhs.candidate.hasSyncedLyrics {
+                    return lhs.candidate.hasSyncedLyrics
+                }
+                return lhs.candidate.trackName.localizedCaseInsensitiveCompare(rhs.candidate.trackName) == .orderedAscending
+            }
+    }
+
+    static func score(candidate: LRCLIBLyricsCandidate, query: LRCLIBSearchQuery) -> Int {
+        var score = 0
+        score += textScore(candidate.trackName, query.trackName, exact: 45, partial: 20)
+        score += textScore(candidate.artistName, query.artistName, exact: 35, partial: 16)
+        score += textScore(candidate.albumName, query.albumName, exact: 20, partial: 8)
+
+        if let queryDuration = query.durationSeconds,
+           let candidateDuration = candidate.durationSeconds {
+            let delta = abs(candidateDuration - queryDuration)
+            switch delta {
+            case 0...1:
+                score += 20
+            case 2...4:
+                score += 12
+            case 5...8:
+                score += 6
+            default:
+                score -= min(delta, 20)
+            }
+        }
+
+        if candidate.hasSyncedLyrics {
+            score += 10
+        } else if candidate.hasPlainLyrics {
+            score -= 6
+        } else if candidate.instrumental {
+            score -= 10
+        }
+
+        return score
+    }
+
+    private static func textScore(
+        _ candidateValue: String,
+        _ queryValue: String,
+        exact: Int,
+        partial: Int
+    ) -> Int {
+        let candidate = normalized(candidateValue)
+        let query = normalized(queryValue)
+        guard !candidate.isEmpty, !query.isEmpty else { return 0 }
+        if candidate == query { return exact }
+        if candidate.contains(query) || query.contains(candidate) { return partial }
+        return 0
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+    }
+}

--- a/AudioMator/Infrastructure/LRCLIB/LRCLIBClient.swift
+++ b/AudioMator/Infrastructure/LRCLIB/LRCLIBClient.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+enum LRCLIBClientError: LocalizedError, Equatable {
+    case emptyQuery
+    case invalidRequest
+    case invalidResponse
+    case requestFailed(statusCode: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyQuery:
+            return "The selected file does not have enough title or artist metadata to search LRCLIB."
+        case .invalidRequest:
+            return "AudioMator could not build a valid LRCLIB request."
+        case .invalidResponse:
+            return "LRCLIB returned an unexpected response."
+        case .requestFailed(let statusCode):
+            return "LRCLIB request failed with HTTP \(statusCode)."
+        }
+    }
+}
+
+struct LRCLIBSearchQuery: Equatable, Sendable {
+    var trackName: String
+    var artistName: String
+    var albumName: String
+    var durationSeconds: Int?
+
+    nonisolated var isEmpty: Bool {
+        trackName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            artistName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            albumName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+struct LRCLIBFileSearchInput: Identifiable, Equatable, Hashable, Sendable {
+    let id: AudioFile.ID
+    let fileName: String
+    let title: String
+    let artist: String
+    let album: String
+    let durationSeconds: Int?
+
+    init(file: AudioFile) {
+        let fallback = MusicBrainzFilenameFallbackResolver.makeSearchInput(for: file)
+        self.id = file.id
+        self.fileName = file.url.lastPathComponent
+        self.title = Self.preferred(file.title, fallback: fallback.title)
+        self.artist = Self.preferred(file.artist, fallback: fallback.artist)
+        self.album = Self.preferred(file.album, fallback: fallback.album)
+        self.durationSeconds = file.duration.isFinite && file.duration > 0
+            ? Int(file.duration.rounded())
+            : fallback.durationMilliseconds.map { Int((Double($0) / 1000.0).rounded()) }
+    }
+
+    var displayTitle: String {
+        if !title.isEmpty { return title }
+        return fileName
+    }
+
+    var query: LRCLIBSearchQuery {
+        LRCLIBSearchQuery(
+            trackName: title,
+            artistName: artist,
+            albumName: album,
+            durationSeconds: durationSeconds
+        )
+    }
+
+    private static func preferred(_ primary: String, fallback: String) -> String {
+        let trimmedPrimary = primary.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedPrimary.isEmpty { return trimmedPrimary }
+        return fallback.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct LRCLIBLyricsCandidate: Decodable, Identifiable, Equatable, Sendable {
+    let id: Int
+    let name: String?
+    let trackName: String
+    let artistName: String
+    let albumName: String
+    let duration: Double?
+    let instrumental: Bool
+    let plainLyrics: String?
+    let syncedLyrics: String?
+
+    var hasSyncedLyrics: Bool {
+        !(syncedLyrics?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+    }
+
+    var hasPlainLyrics: Bool {
+        !(plainLyrics?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+    }
+
+    var durationSeconds: Int? {
+        duration.map { Int($0.rounded()) }
+    }
+
+    var lyricsAvailabilityLabel: String {
+        if hasSyncedLyrics { return "Synced" }
+        if hasPlainLyrics { return "Plain only" }
+        if instrumental { return "Instrumental" }
+        return "No lyrics"
+    }
+}
+
+protocol LRCLIBLyricsSearching: Sendable {
+    nonisolated func search(matching query: LRCLIBSearchQuery, limit: Int) async throws -> [LRCLIBLyricsCandidate]
+}
+
+struct LRCLIBClient: LRCLIBLyricsSearching {
+    nonisolated private static let baseURL = URL(string: "https://lrclib.net")!
+
+    private let session: URLSession
+    private let userAgent: String
+
+    nonisolated init(session: URLSession = .shared) {
+        self.session = session
+
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.chrislloydme.AudioMator"
+        let contactURL = "https://github.com/ChrisLloydME/AudioMator"
+        self.userAgent = "AudioMator/\(version) (\(contactURL); \(bundleIdentifier))"
+    }
+
+    nonisolated func search(matching query: LRCLIBSearchQuery, limit: Int = 20) async throws -> [LRCLIBLyricsCandidate] {
+        guard !query.isEmpty else { throw LRCLIBClientError.emptyQuery }
+
+        let request = try makeSearchRequest(for: query)
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LRCLIBClientError.invalidResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw LRCLIBClientError.requestFailed(statusCode: httpResponse.statusCode)
+        }
+
+        let candidates = try JSONDecoder().decode([LRCLIBLyricsCandidate].self, from: data)
+        return Array(candidates.prefix(max(1, limit)))
+    }
+
+    nonisolated func makeSearchRequest(for query: LRCLIBSearchQuery) throws -> URLRequest {
+        guard !query.isEmpty else { throw LRCLIBClientError.emptyQuery }
+
+        var components = URLComponents(
+            url: Self.baseURL.appending(path: "api").appending(path: "search"),
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = Self.queryItems(for: query)
+
+        guard let url = components?.url else {
+            throw LRCLIBClientError.invalidRequest
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: 15)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    nonisolated private static func queryItems(for query: LRCLIBSearchQuery) -> [URLQueryItem] {
+        var items: [URLQueryItem] = []
+        appendItem(name: "track_name", value: query.trackName, to: &items)
+        appendItem(name: "artist_name", value: query.artistName, to: &items)
+        appendItem(name: "album_name", value: query.albumName, to: &items)
+        if let durationSeconds = query.durationSeconds, durationSeconds > 0 {
+            items.append(URLQueryItem(name: "duration", value: String(durationSeconds)))
+        }
+        return items
+    }
+
+    nonisolated private static func appendItem(name: String, value: String, to items: inout [URLQueryItem]) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        items.append(URLQueryItem(name: name, value: trimmed))
+    }
+}

--- a/AudioMatorTests/LRCLIBLyricsTests.swift
+++ b/AudioMatorTests/LRCLIBLyricsTests.swift
@@ -1,0 +1,341 @@
+import Foundation
+import XCTest
+@testable import AudioMator
+
+final class LRCLIBLyricsTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testSearchRequestUsesExpectedQueryItemsAndHeaders() throws {
+        let client = LRCLIBClient()
+        let request = try client.makeSearchRequest(
+            for: LRCLIBSearchQuery(
+                trackName: "Sweeter Than Fiction",
+                artistName: "Taylor Swift",
+                albumName: "Single",
+                durationSeconds: 235
+            )
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.scheme, "https")
+        XCTAssertEqual(components.host, "lrclib.net")
+        XCTAssertEqual(components.path, "/api/search")
+
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+        XCTAssertEqual(queryItems["track_name"], "Sweeter Than Fiction")
+        XCTAssertEqual(queryItems["artist_name"], "Taylor Swift")
+        XCTAssertEqual(queryItems["album_name"], "Single")
+        XCTAssertEqual(queryItems["duration"], "235")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+        XCTAssertTrue(request.value(forHTTPHeaderField: "User-Agent")?.contains("AudioMator/") == true)
+    }
+
+    func testSearchDecodesSyncedPlainInstrumentalAndEmptyResults() async throws {
+        let payload = """
+        [
+          {
+            "id": 1,
+            "name": "Synced",
+            "trackName": "Synced Song",
+            "artistName": "Artist",
+            "albumName": "Album",
+            "duration": 200,
+            "instrumental": false,
+            "plainLyrics": "plain",
+            "syncedLyrics": "[00:01.00]synced"
+          },
+          {
+            "id": 2,
+            "name": "Plain",
+            "trackName": "Plain Song",
+            "artistName": "Artist",
+            "albumName": "Album",
+            "duration": 201,
+            "instrumental": false,
+            "plainLyrics": "plain only",
+            "syncedLyrics": null
+          },
+          {
+            "id": 3,
+            "name": "Instrumental",
+            "trackName": "Instrumental Song",
+            "artistName": "Artist",
+            "albumName": "Album",
+            "duration": 202,
+            "instrumental": true,
+            "plainLyrics": null,
+            "syncedLyrics": null
+          }
+        ]
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, payload)
+        }
+
+        let client = LRCLIBClient(session: makeMockSession())
+        let results = try await client.search(
+            matching: LRCLIBSearchQuery(trackName: "Song", artistName: "Artist", albumName: "", durationSeconds: nil),
+            limit: 20
+        )
+
+        XCTAssertEqual(results.count, 3)
+        XCTAssertTrue(results[0].hasSyncedLyrics)
+        XCTAssertTrue(results[1].hasPlainLyrics)
+        XCTAssertFalse(results[1].hasSyncedLyrics)
+        XCTAssertTrue(results[2].instrumental)
+        XCTAssertEqual(results[2].lyricsAvailabilityLabel, "Instrumental")
+    }
+
+    func testRankingSortsExactSyncedDurationCloseCandidateFirst() {
+        let query = LRCLIBSearchQuery(
+            trackName: "Sweeter Than Fiction",
+            artistName: "Taylor Swift",
+            albumName: "Single",
+            durationSeconds: 235
+        )
+        let candidates = [
+            makeCandidate(id: 1, track: "Sweeter Than Fiction", artist: "Taylor Swift", album: "Single", duration: 235, syncedLyrics: "[00:01.00]Line"),
+            makeCandidate(id: 2, track: "Sweeter Than Fiction", artist: "Taylor Swift", album: "Single", duration: 260, plainLyrics: "Line"),
+            makeCandidate(id: 3, track: "Sweeter", artist: "Other Artist", album: "Other", duration: 235, syncedLyrics: "[00:01.00]Line")
+        ]
+
+        let ranked = LRCLIBCandidateRanker.rankedCandidates(candidates, for: query)
+
+        XCTAssertEqual(ranked.map(\.id), [1, 2, 3])
+        XCTAssertGreaterThan(ranked[0].score, ranked[1].score)
+    }
+
+    @MainActor
+    func testStoreHandlesNoResultsNoSyncedLyricsCancellationAndQueueNavigation() async throws {
+        let firstFile = AudioFileTestFactory.make(
+            id: UUID(),
+            url: URL(fileURLWithPath: "/tmp/01 - First.m4a"),
+            title: "First",
+            artist: "Artist"
+        )
+        let secondFile = AudioFileTestFactory.make(
+            id: UUID(),
+            url: URL(fileURLWithPath: "/tmp/02 - Second.m4a"),
+            title: "Second",
+            artist: "Artist"
+        )
+        let client = MockLRCLIBSearchClient(results: [
+            firstFile.id: [],
+            secondFile.id: [
+                makeCandidate(id: 10, track: "Second", artist: "Artist", album: "", duration: nil, plainLyrics: "Plain only")
+            ]
+        ])
+        let store = LRCLIBLyricsBrowserStore(client: client)
+
+        store.seed(from: [firstFile, secondFile])
+        store.searchCurrentFile()
+        try await waitForSearchToFinish(store)
+        XCTAssertEqual(store.searchState, .loaded)
+        XCTAssertTrue(store.rankedCandidates.isEmpty)
+
+        store.moveNext()
+        store.searchCurrentFile()
+        try await waitForSearchToFinish(store)
+        XCTAssertEqual(store.queuePositionText, "2 of 2")
+        XCTAssertFalse(store.hasSyncedCandidate)
+        XCTAssertFalse(store.canApplySelectedCandidate)
+        XCTAssertEqual(store.selectedCandidate?.lyricsAvailabilityLabel, "Plain only")
+
+        store.movePrevious()
+        XCTAssertEqual(store.queuePositionText, "1 of 2")
+
+        let slowStore = LRCLIBLyricsBrowserStore(client: MockLRCLIBSearchClient(delayNanoseconds: 2_000_000_000))
+        slowStore.seed(from: [firstFile])
+        slowStore.searchCurrentFile()
+        slowStore.cancelSearch()
+        XCTAssertEqual(slowStore.searchState, .cancelled)
+    }
+
+    @MainActor
+    func testApplyingSyncedLyricsWritesOnlyLyricsPropertyThroughRawMetadataPath() async throws {
+        let file = AudioFileTestFactory.make(
+            id: UUID(),
+            url: URL(fileURLWithPath: "/tmp/lyrics-target.m4a"),
+            title: "Title",
+            artist: "Artist"
+        )
+        let pipeline = RecordingRawMetadataPipeline(
+            file: file,
+            initialPropertyMap: [
+                "TITLE": "Title",
+                "ARTIST": "Artist"
+            ]
+        )
+        let viewModel = AudioViewModel(metadataPipeline: pipeline)
+        viewModel.files = [file]
+
+        let didApply = await viewModel.applyLRCLIBSyncedLyrics("  [00:01.00]Synced line\n", to: file.id)
+
+        XCTAssertTrue(didApply)
+        XCTAssertEqual(pipeline.writtenPropertyMap?["TITLE"], "Title")
+        XCTAssertEqual(pipeline.writtenPropertyMap?["ARTIST"], "Artist")
+        XCTAssertEqual(pipeline.writtenPropertyMap?["LYRICS"], "[00:01.00]Synced line")
+        XCTAssertEqual(pipeline.writtenPropertyMap?.count, 3)
+    }
+
+    private func makeMockSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func waitForSearchToFinish(
+        _ store: LRCLIBLyricsBrowserStore,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(2)
+        while store.searchState == .searching && Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertNotEqual(store.searchState, .searching, "Timed out waiting for LRCLIB search", file: file, line: line)
+    }
+}
+
+private func makeCandidate(
+    id: Int,
+    track: String,
+    artist: String,
+    album: String,
+    duration: Double?,
+    plainLyrics: String? = nil,
+    syncedLyrics: String? = nil,
+    instrumental: Bool = false
+) -> LRCLIBLyricsCandidate {
+    LRCLIBLyricsCandidate(
+        id: id,
+        name: track,
+        trackName: track,
+        artistName: artist,
+        albumName: album,
+        duration: duration,
+        instrumental: instrumental,
+        plainLyrics: plainLyrics,
+        syncedLyrics: syncedLyrics
+    )
+}
+
+private final class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: LRCLIBClientError.invalidResponse)
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class MockLRCLIBSearchClient: LRCLIBLyricsSearching, @unchecked Sendable {
+    private let results: [AudioFile.ID: [LRCLIBLyricsCandidate]]
+    private let delayNanoseconds: UInt64
+
+    init(
+        results: [AudioFile.ID: [LRCLIBLyricsCandidate]] = [:],
+        delayNanoseconds: UInt64 = 0
+    ) {
+        self.results = results
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func search(matching query: LRCLIBSearchQuery, limit: Int) async throws -> [LRCLIBLyricsCandidate] {
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+
+        let match = results.first { _, candidates in
+            candidates.contains { candidate in
+                candidate.trackName == query.trackName
+            }
+        }
+        return match?.value ?? []
+    }
+}
+
+private final class RecordingRawMetadataPipeline: AudioMetadataPipeline, @unchecked Sendable {
+    private let file: AudioFile
+    private let initialPropertyMap: [String: String]
+    private let lock = NSLock()
+    private var _writtenPropertyMap: [String: String]?
+
+    init(file: AudioFile, initialPropertyMap: [String: String]) {
+        self.file = file
+        self.initialPropertyMap = initialPropertyMap
+    }
+
+    var writtenPropertyMap: [String: String]? {
+        lock.withLock { _writtenPropertyMap }
+    }
+
+    nonisolated func loadAudioFile(at url: URL, id: UUID) async throws -> AudioFile {
+        file
+    }
+
+    nonisolated func rawMetadataDumpText(for url: URL) -> String? {
+        nil
+    }
+
+    nonisolated func rawMetadataPropertyMap(for url: URL) throws -> [String: String] {
+        initialPropertyMap
+    }
+
+    nonisolated func writeMetadata(_ edit: MetadataEditPayload, to url: URL) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+
+    nonisolated func writeRawMetadataPropertyMap(_ propertyMap: [String: String], to url: URL) throws -> AudioMetadataWriteResult {
+        lock.withLock {
+            _writtenPropertyMap = propertyMap
+        }
+        return AudioMetadataWriteResult(warnings: [])
+    }
+
+    nonisolated func eraseAllMetadata(at url: URL) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+
+    nonisolated func writeTrackNumberText(
+        _ trackNumberText: String,
+        discNumberText: String?,
+        to url: URL,
+        verifyAfterWrite: Bool
+    ) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ AudioMator is a local-first audio metadata workbench for inspecting, organizing,
 
 ### Online tagging
 
-- Search online metadata sources through MusicBrainz and iTunes.
+- Search online metadata sources through MusicBrainz, iTunes, and LRCLIB.
 - Search from selected files using existing tags and filename fallback.
 - Review recordings, releases, media, track lists, identifiers, dates, artist credits, labels, catalog numbers, countries, genres, tags, ratings, and relationships before applying.
 - Use the tagging workbench to map selected files to release tracks.
+- Search LRCLIB for synced lyrics candidates from selected track metadata.
+- Review LRCLIB candidates one track at a time, with synced/plain-only state shown before applying lyrics.
 - Apply chosen fields back to local files through the same metadata write path used by the inspector.
 
 ### Inspection and raw metadata tools
@@ -81,7 +83,7 @@ The macOS build is the full desktop workflow:
 - Current Session import for one-off work.
 - Persistent watched folders with automatic rescans.
 - Sidebar, middle list, and inspector in a native three-pane window.
-- Dedicated windows for MusicBrainz Browser, Filename & Metadata, and Metadata Editor.
+- Dedicated windows for Online Metadata, Filename & Metadata, and Metadata Editor.
 - File-path display in the inspector.
 - Finder-style actions such as reveal in Finder, open with the default app, and copy path.
 - Configurable toolbar buttons.
@@ -184,9 +186,9 @@ E-mail: AudioMator@lloydME.com
 - `AudioMator/Domain/`
   Metadata pipeline models, audio-file models, rename templates, file sources, track renumbering, and UI state.
 - `AudioMator/Features/`
-  SwiftUI feature areas for the main window, iPad workspace, online metadata browser, provider-specific metadata browsers, metadata editor, settings, filename tools, metadata inspector, and welcome flow.
+  SwiftUI feature areas for the main window, iPad workspace, online metadata browser, provider-specific metadata and lyrics browsers, metadata editor, settings, filename tools, metadata inspector, and welcome flow.
 - `AudioMator/Infrastructure/`
-  File-system monitoring, MusicBrainz, iTunes Search API/artwork, and GitHub release-note services.
+  File-system monitoring, MusicBrainz, iTunes Search API/artwork, LRCLIB lyrics lookup, and GitHub release-note services.
 - `Config/`
   Project configuration inputs, including the app Info.plist.
 - `scripts/`

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Network access happens only when you explicitly use an online feature:
 
 - MusicBrainz lookup and tagging contacts `musicbrainz.org`.
 - iTunes metadata and artwork lookup contacts the Apple iTunes Search API at `itunes.apple.com` and Apple artwork CDN hosts.
+- LRCLIB synced lyrics lookup contacts `lrclib.net`.
 - Release-note lookup may contact `api.github.com`.
 - Sparkle update infrastructure is present for macOS, but update checking is currently disabled.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -62,6 +62,16 @@ The referenced project is released under The Unlicense. Where recognized, the wo
 
 The iTunes Search API is an Apple web service, not third-party source code bundled into AudioMator. Keep privacy disclosures current when changing the iTunes lookup flow, because queries may include metadata-derived search terms, storefront country, UPC/barcode values, Apple Music or iTunes links, and Apple/iTunes catalog IDs.
 
+## LRCLIB
+
+- **Project / service**: LRCLIB
+- **Source**: https://github.com/tranxuanthang/lrclib
+- **Usage in this repository**: optional web-service lookup for synced lyrics candidates. AudioMator's LRCLIB client implementation is written in Swift in this repository.
+
+### Service Notice
+
+LRCLIB is a public lyrics service, not third-party source code bundled into AudioMator. Keep privacy disclosures current when changing the LRCLIB lookup flow, because queries may include metadata-derived title, artist, album, and duration values.
+
 ## Sparkle
 
 - **Project**: Sparkle


### PR DESCRIPTION
## Summary

This PR adds LRCLIB as a first-class Online Metadata source alongside MusicBrainz and iTunes. Users can select one or more audio files, search LRCLIB from the existing track metadata, review ranked lyric candidates, preview synced lyrics, and manually apply the chosen synced lyric text to AudioMator's existing Lyrics field.

The workflow stays track-by-track for multi-file selections. AudioMator does not pick or write a candidate automatically, and plain-only LRCLIB results stay visible without being treated as synced lyrics.

## What changed

- Added a visible LRCLIB entry to the Online Metadata source picker.
- Added a dedicated LRCLIB client, response models, query builder, and candidate ranker under `AudioMator/Infrastructure/LRCLIB/`.
- Added a macOS LRCLIB lyrics review workflow under `AudioMator/Features/LRCLIBLyricsBrowser/`.
- Seeded LRCLIB searches from AudioMator's current metadata model plus the existing filename fallback resolver.
- Added one-by-one queue navigation for multi-file selections.
- Applied selected synced lyrics through the existing raw metadata property-map write path by updating only `LYRICS`.
- Updated README, acknowledgements/privacy, third-party notices, and welcome-screen network disclosure copy for LRCLIB.
- Added focused LRCLIB tests for request construction, decoding, ranking, store states, queue navigation, and lyrics application.

## Validation

- `bash scripts/codex-build.sh`
- `xcodebuild -project AudioMator.xcodeproj -scheme AudioMator -configuration Debug -destination 'platform=macOS' -derivedDataPath .deriveddata-codex CODE_SIGNING_ALLOWED=NO test`
- `xcodebuild -project AudioMator.xcodeproj -scheme AudioMator -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath .deriveddata-codex CODE_SIGNING_ALLOWED=NO build`

The iOS build passes with the existing project validation warnings.
