### PR TITLE
Refactor macOS welcome onboarding

### DIFF
--- a/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+struct MacWelcomeSplashView: View {
+    let onQuit: () -> Void
+    let onContinue: () -> Void
+
+    @State private var currentPage: WelcomeSplashPage = .welcome
+
+    var body: some View {
+        ScrollView(.vertical) {
+            MacWelcomeSplashPageView(content: currentPage.content)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.horizontal, 30)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
+        }
+        .scrollIndicators(.hidden)
+        .safeAreaBar(edge: .top, spacing: 0) {
+            Color.clear
+                .frame(height: 18)
+        }
+        .safeAreaBar(edge: .bottom, spacing: 0) {
+            MacWelcomeSplashButtonBar(
+                currentPage: currentPage,
+                onQuit: onQuit,
+                onBack: retreat,
+                onContinue: advance
+            )
+            .padding(.horizontal, 30)
+            .padding(.top, 14)
+            .padding(.bottom, 30)
+        }
+        .audiomatorScrollEdgeEffect(.soft, for: .vertical)
+        .frame(width: 750, height: 700)
+        .background(MacWelcomeWindowConfigurator())
+        .animation(.easeInOut(duration: 0.18), value: currentPage)
+    }
+
+    private func advance() {
+        guard let nextPage = currentPage.next else {
+            onContinue()
+            return
+        }
+
+        currentPage = nextPage
+    }
+
+    private func retreat() {
+        guard let previousPage = currentPage.previous else { return }
+        currentPage = previousPage
+    }
+}
+
+private struct MacWelcomeSplashPageView: View {
+    let content: WelcomeSplashPageContent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: content.page == .welcome ? 28 : 26) {
+            MacWelcomeSplashHeader(title: content.title, subtitle: content.subtitle)
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: content.page == .features ? 23 : 24) {
+                    ForEach(content.rows) { row in
+                        MacWelcomeSplashRow(row: row)
+                    }
+
+                    if content.page == .privacy {
+                        Text(WelcomeSplashPage.domainSummary)
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .padding(.leading, 66)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.vertical, content.page == .features || content.page == .privacy ? 20 : 22)
+            }
+        }
+        .padding(.top, content.topPadding)
+    }
+}
+
+private struct MacWelcomeSplashHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let image = PlatformApplication.appIconImage {
+                Image(platformImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 104, height: 104)
+                    .padding(.top, 4)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.system(size: 35, weight: .semibold))
+
+                Text(subtitle)
+                    .font(.system(size: 17))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+private struct MacWelcomeSplashRow: View {
+    let row: WelcomeSplashRowContent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 18) {
+            Image(systemName: row.symbol)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 30, height: 30)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(row.title)
+                    .font(.system(size: 18, weight: .semibold))
+
+                Text(row.description)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, 18)
+    }
+}
+
+private struct MacWelcomeSplashButtonBar: View {
+    let currentPage: WelcomeSplashPage
+    let onQuit: () -> Void
+    let onBack: () -> Void
+    let onContinue: () -> Void
+
+    var body: some View {
+        HStack {
+            if currentPage == .welcome {
+                Button("Quit", action: onQuit)
+                    .buttonStyle(MacWelcomeGlassButtonStyle())
+                    .keyboardShortcut(.cancelAction)
+            } else {
+                Button("Back", action: onBack)
+                    .buttonStyle(MacWelcomeGlassButtonStyle())
+                    .keyboardShortcut(.cancelAction)
+            }
+
+            Spacer()
+
+            Button(currentPage.next == nil ? "Get Started" : "Continue", action: onContinue)
+                .buttonStyle(MacWelcomeGlassButtonStyle(isProminent: true))
+                .keyboardShortcut(.defaultAction)
+        }
+    }
+}
+
+private struct MacWelcomeGlassButtonStyle: ButtonStyle {
+    var isProminent: Bool = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(isProminent ? Color.white : Color.primary.opacity(0.86))
+            .frame(minWidth: 108)
+            .padding(.horizontal, 22)
+            .padding(.vertical, 12)
+            .background(prominentFill(configuration: configuration))
+            .glassEffect(.regular, in: .capsule)
+            .shadow(color: shadowColor(configuration: configuration), radius: 11, x: 0, y: 6)
+            .scaleEffect(configuration.isPressed ? 0.985 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+
+    @ViewBuilder
+    private func prominentFill(configuration: Configuration) -> some View {
+        if isProminent {
+            Capsule(style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accentColor.opacity(configuration.isPressed ? 0.76 : 0.92),
+                            Color.accentColor.opacity(configuration.isPressed ? 0.58 : 0.76)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        } else {
+            Color.clear
+        }
+    }
+
+    private func shadowColor(configuration: Configuration) -> Color {
+        isProminent
+            ? Color.accentColor.opacity(configuration.isPressed ? 0.12 : 0.20)
+            : Color.black.opacity(configuration.isPressed ? 0.03 : 0.07)
+    }
+}
+
+private struct MacWelcomeWindowConfigurator: NSViewRepresentable {
+    func makeNSView(context: Context) -> MacWelcomeWindowObserverView {
+        MacWelcomeWindowObserverView()
+    }
+
+    func updateNSView(_ nsView: MacWelcomeWindowObserverView, context: Context) {
+        DispatchQueue.main.async {
+            configure(window: nsView.window)
+        }
+    }
+
+    private func configure(window: NSWindow?) {
+        guard let window else { return }
+        window.minSize = NSSize(width: 750, height: 700)
+        window.maxSize = NSSize(width: 750, height: 700)
+    }
+}
+
+private final class MacWelcomeWindowObserverView: NSView {
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard let window else { return }
+        window.minSize = NSSize(width: 750, height: 700)
+        window.maxSize = NSSize(width: 750, height: 700)
+    }
+}
+#endif

--- a/AudioMator/Features/Welcome/Views/SwiftUIWelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/SwiftUIWelcomeSplashView.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+#if os(iOS)
+struct SwiftUIWelcomeSplashView: View {
+    let onQuit: () -> Void
+    let onContinue: () -> Void
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var currentPage: WelcomeSplashPage = .welcome
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            WelcomeSplashPageView(content: currentPage.content)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            Spacer(minLength: 0)
+
+            WelcomeSplashButtonBar(
+                currentPage: currentPage,
+                onCancel: platformCancelAction,
+                onBack: retreat,
+                onContinue: advance
+            )
+        }
+        .padding(.horizontal, 30)
+        .padding(.top, 30)
+        .padding(.bottom, 30)
+        .frame(
+            minWidth: nil,
+            idealWidth: 750,
+            maxWidth: horizontalSizeClass == .compact ? .infinity : 750,
+            minHeight: nil,
+            idealHeight: 700,
+            maxHeight: .infinity
+        )
+        .background(.regularMaterial)
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(.thinMaterial)
+        .animation(.easeInOut(duration: 0.18), value: currentPage)
+    }
+
+    private func advance() {
+        guard let nextPage = currentPage.next else {
+            onContinue()
+            return
+        }
+
+        currentPage = nextPage
+    }
+
+    private func retreat() {
+        guard let previousPage = currentPage.previous else { return }
+        currentPage = previousPage
+    }
+
+    private func platformCancelAction() {
+        onContinue()
+    }
+}
+
+private struct WelcomeSplashButtonBar: View {
+    let currentPage: WelcomeSplashPage
+    let onCancel: () -> Void
+    let onBack: () -> Void
+    let onContinue: () -> Void
+
+    var body: some View {
+        HStack {
+            if currentPage == .welcome {
+                Button("Skip", action: onCancel)
+                    .buttonStyle(GlassActionButtonStyle())
+                    .keyboardShortcut(.cancelAction)
+            } else {
+                Button("Back", action: onBack)
+                    .buttonStyle(GlassActionButtonStyle())
+                    .keyboardShortcut(.cancelAction)
+            }
+
+            Spacer()
+
+            Button(currentPage.next == nil ? "Get Started" : "Continue", action: onContinue)
+                .buttonStyle(GlassActionButtonStyle(isProminent: true))
+                .keyboardShortcut(.defaultAction)
+        }
+    }
+}
+
+private struct WelcomeSplashPageView: View {
+    let content: WelcomeSplashPageContent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: content.page == .welcome ? 28 : 26) {
+            WelcomeSplashHeader(title: content.title, subtitle: content.subtitle)
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: content.page == .features ? 23 : 24) {
+                    ForEach(content.rows) { row in
+                        WelcomeSplashRow(row: row)
+                    }
+
+                    if content.page == .privacy {
+                        Text(WelcomeSplashPage.domainSummary)
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .padding(.leading, 66)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.vertical, content.page == .features || content.page == .privacy ? 20 : 22)
+            }
+        }
+        .padding(.top, content.topPadding)
+    }
+}
+
+private struct WelcomeSplashHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let image = PlatformApplication.appIconImage {
+                Image(platformImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 104, height: 104)
+                    .padding(.top, 4)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.system(size: 35, weight: .semibold))
+
+                Text(subtitle)
+                    .font(.system(size: 17))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+private struct WelcomeSplashRow: View {
+    let row: WelcomeSplashRowContent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 18) {
+            Image(systemName: row.symbol)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 30, height: 30)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(row.title)
+                    .font(.system(size: 18, weight: .semibold))
+
+                Text(row.description)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, 18)
+    }
+}
+
+private struct GlassActionButtonStyle: ButtonStyle {
+    var isProminent: Bool = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(foregroundColor)
+            .frame(minWidth: 108)
+            .padding(.horizontal, 22)
+            .padding(.vertical, 12)
+            .background(background(configuration: configuration))
+            .overlay(border(configuration: configuration))
+            .clipShape(Capsule(style: .continuous))
+            .shadow(color: shadowColor(configuration: configuration), radius: 10, x: 0, y: 6)
+            .scaleEffect(configuration.isPressed ? 0.985 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+
+    private var foregroundColor: Color {
+        isProminent ? .white : Color.primary.opacity(0.82)
+    }
+
+    @ViewBuilder
+    private func background(configuration: Configuration) -> some View {
+        if isProminent {
+            Capsule(style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accentColor.opacity(configuration.isPressed ? 0.82 : 0.94),
+                            Color.accentColor.opacity(configuration.isPressed ? 0.66 : 0.80)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .background(.ultraThinMaterial, in: Capsule(style: .continuous))
+        } else {
+            Capsule(style: .continuous)
+                .fill(.regularMaterial)
+                .opacity(configuration.isPressed ? 0.88 : 1)
+        }
+    }
+
+    @ViewBuilder
+    private func border(configuration: Configuration) -> some View {
+        Capsule(style: .continuous)
+            .strokeBorder(
+                isProminent
+                    ? Color.white.opacity(configuration.isPressed ? 0.18 : 0.26)
+                    : Color.primary.opacity(configuration.isPressed ? 0.10 : 0.14),
+                lineWidth: 1
+            )
+    }
+
+    private func shadowColor(configuration: Configuration) -> Color {
+        isProminent
+            ? Color.accentColor.opacity(configuration.isPressed ? 0.14 : 0.22)
+            : Color.black.opacity(configuration.isPressed ? 0.04 : 0.08)
+    }
+}
+#endif

--- a/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
@@ -4,221 +4,183 @@ struct WelcomeSplashView: View {
     let onQuit: () -> Void
     let onContinue: () -> Void
 
-    @State private var currentPage: WelcomeSplashPage = .welcome
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 22) {
-            pageContent
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-            Spacer(minLength: 0)
-
-            HStack {
-                if currentPage == .welcome {
-                    Button(platformCancelTitle) {
-                        platformCancelAction()
-                    }
-                    .buttonStyle(GlassActionButtonStyle())
-                    .keyboardShortcut(.cancelAction)
-                } else {
-                    Button("Back") {
-                        retreat()
-                    }
-                    .buttonStyle(GlassActionButtonStyle())
-                    .keyboardShortcut(.cancelAction)
-                }
-
-                Spacer()
-
-                Button(currentPage.next == nil ? "Get Started" : "Continue") {
-                    advance()
-                }
-                .buttonStyle(GlassActionButtonStyle(isProminent: true))
-                .keyboardShortcut(.defaultAction)
-            }
-        }
-        .padding(.horizontal, 30)
-        .padding(.top, 30)
-        .padding(.bottom, 30)
-        .frame(
-            minWidth: minimumWidth,
-            idealWidth: 750,
-            maxWidth: maximumWidth,
-            minHeight: minimumHeight,
-            idealHeight: 700,
-            maxHeight: maximumHeight
-        )
-        #if os(iOS)
-        .background(.regularMaterial)
-        .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
-        .presentationBackground(.thinMaterial)
-        #endif
-        .animation(.easeInOut(duration: 0.18), value: currentPage)
-    }
-
-    @ViewBuilder
-    private var pageContent: some View {
-        switch currentPage {
-        case .welcome:
-            WelcomePage()
-        case .features:
-            FeaturesPage()
-        case .musicBrainz:
-            MusicBrainzPage()
-        case .artwork:
-            ArtworkPage()
-        case .privacy:
-            NetworkPrivacyPage()
-        }
-    }
-
-    private func advance() {
-        guard let nextPage = currentPage.next else {
-            onContinue()
-            return
-        }
-
-        currentPage = nextPage
-    }
-
-    private func retreat() {
-        guard let previousPage = currentPage.previous else { return }
-        currentPage = previousPage
-    }
-
-    private var platformCancelTitle: String {
         #if os(macOS)
-        "Quit"
+        MacWelcomeSplashView(onQuit: onQuit, onContinue: onContinue)
+            .frame(width: 750, height: 700)
         #else
-        "Skip"
-        #endif
-    }
-
-    private func platformCancelAction() {
-        #if os(macOS)
-        onQuit()
-        #else
-        onContinue()
-        #endif
-    }
-
-    private var minimumWidth: CGFloat? {
-        #if os(macOS)
-        750
-        #else
-        nil
-        #endif
-    }
-
-    private var maximumWidth: CGFloat? {
-        #if os(macOS)
-        750
-        #else
-        horizontalSizeClass == .compact ? .infinity : 750
-        #endif
-    }
-
-    private var minimumHeight: CGFloat? {
-        #if os(macOS)
-        700
-        #else
-        nil
-        #endif
-    }
-
-    private var maximumHeight: CGFloat? {
-        #if os(macOS)
-        700
-        #else
-        .infinity
+        SwiftUIWelcomeSplashView(onQuit: onQuit, onContinue: onContinue)
         #endif
     }
 }
 
-private enum WelcomeSplashPage: Int {
+struct WelcomeSplashPageContent: Identifiable {
+    let page: WelcomeSplashPage
+    let title: String
+    let subtitle: String
+    let rows: [WelcomeSplashRowContent]
+    var topPadding: CGFloat = 8
+
+    var id: WelcomeSplashPage { page }
+}
+
+struct WelcomeSplashRowContent: Identifiable {
+    let symbol: String
+    let title: String
+    let description: String
+
+    var id: String { "\(symbol)-\(title)" }
+}
+
+enum WelcomeSplashPage: Int, CaseIterable {
     case welcome
     case features
-    case musicBrainz
+    case onlineMetadata
     case artwork
     case privacy
 
     var next: WelcomeSplashPage? {
-        switch self {
-        case .welcome:
-            .features
-        case .features:
-            .musicBrainz
-        case .musicBrainz:
-            .artwork
-        case .artwork:
-            .privacy
-        case .privacy:
-            nil
-        }
+        WelcomeSplashPage(rawValue: rawValue + 1)
     }
 
     var previous: WelcomeSplashPage? {
+        WelcomeSplashPage(rawValue: rawValue - 1)
+    }
+
+    var content: WelcomeSplashPageContent {
         switch self {
         case .welcome:
-            nil
-        case .features:
-            .welcome
-        case .musicBrainz:
-            .features
-        case .artwork:
-            .musicBrainz
-        case .privacy:
-            .artwork
-        }
-    }
-}
-
-private struct AppIconHero: View {
-    var body: some View {
-        if let image = PlatformApplication.appIconImage {
-            Image(platformImage: image)
-                .resizable()
-                .interpolation(.high)
-                .scaledToFit()
-                .frame(width: 104, height: 104)
-        }
-    }
-}
-
-private struct WelcomePage: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 28) {
-            PageHeader(
+            WelcomeSplashPageContent(
+                page: self,
                 title: "Welcome to AudioMator",
-                subtitle: "Inspect, clean up, and rewrite audio metadata on \(platformDeviceName)."
-            )
-
-            GroupBox {
-                VStack(alignment: .leading, spacing: 24) {
-                    WelcomeIntroRow(
+                subtitle: "Inspect, clean up, and rewrite audio metadata on \(Self.platformDeviceName).",
+                rows: [
+                    WelcomeSplashRowContent(
                         symbol: "music.note",
-                        title: "Edit metadata on \(platformDeviceName)",
+                        title: "Edit metadata on \(Self.platformDeviceName)",
                         description: "Open the tracks you want and work locally."
-                    )
-                    WelcomeIntroRow(
+                    ),
+                    WelcomeSplashRowContent(
                         symbol: "wand.and.stars",
                         title: "Review tags quickly",
                         description: "Spot important fields fast and make precise fixes."
-                    )
-                    WelcomeIntroRow(
-                        symbol: platformNativeSymbol,
-                        title: "Feels native on \(platformName)",
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: Self.platformNativeSymbol,
+                        title: "Feels native on \(Self.platformName)",
                         description: "Uses familiar windows, sheets, and inspectors."
                     )
-                }
-                .padding(.vertical, 22)
-            }
+                ],
+                topPadding: 0
+            )
+        case .features:
+            WelcomeSplashPageContent(
+                page: self,
+                title: "What You Can Do",
+                subtitle: "Bring in tracks, inspect tags, make precise changes, and save when you're ready.",
+                rows: [
+                    WelcomeSplashRowContent(
+                        symbol: "music.note.list",
+                        title: "Choose one-time or watched sources",
+                        description: "Use Current Session for one-off work, or add watched folders for later."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "slider.horizontal.3",
+                        title: "Inspect and edit metadata",
+                        description: "Review tags, compare selections, and check raw metadata before saving."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "square.stack.3d.down.right",
+                        title: "Use batch utilities",
+                        description: "Reorder files, renumber tracks, copy paths, reveal files, or clear tags."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "photo.on.rectangle.angled",
+                        title: "Work with artwork",
+                        description: "Replace, remove, preview, and apply album artwork from the inspector."
+                    )
+                ]
+            )
+        case .onlineMetadata:
+            WelcomeSplashPageContent(
+                page: self,
+                title: "Match Online Metadata",
+                subtitle: "Search MusicBrainz, iTunes, and LRCLIB, compare candidates, and apply only the details you choose.",
+                rows: [
+                    WelcomeSplashRowContent(
+                        symbol: "magnifyingglass",
+                        title: "Search from selected files",
+                        description: "Start with existing track metadata, IDs, links, filenames, or your own search terms."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "list.bullet.rectangle",
+                        title: "Review before applying",
+                        description: "Check MusicBrainz releases, iTunes catalog matches, and LRCLIB synced lyrics before they change your files."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "square.and.arrow.down",
+                        title: "Apply metadata when ready",
+                        description: "Write matched titles, artists, album details, dates, identifiers, artwork, and lyrics."
+                    )
+                ]
+            )
+        case .artwork:
+            WelcomeSplashPageContent(
+                page: self,
+                title: "Find Album Artwork",
+                subtitle: "Use iTunes artwork lookup to find covers, preview them, and apply the selected image.",
+                rows: [
+                    WelcomeSplashRowContent(
+                        symbol: "magnifyingglass.circle",
+                        title: "Find covers online",
+                        description: "Search from album details, an iTunes Album ID, or your own artwork search terms."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "rectangle.on.rectangle",
+                        title: "Preview the result",
+                        description: "Compare available artwork before choosing what to use."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "checkmark.rectangle.stack",
+                        title: "Apply to selected files",
+                        description: "Save selected artwork into supported audio files with your metadata edits."
+                    )
+                ]
+            )
+        case .privacy:
+            WelcomeSplashPageContent(
+                page: self,
+                title: "Privacy & Network Access",
+                subtitle: "AudioMator edits files locally. Online services are contacted only when you use lookup features.",
+                rows: [
+                    WelcomeSplashRowContent(
+                        symbol: "internaldrive",
+                        title: "Your audio stays local",
+                        description: "AudioMator reads and writes the files you choose. Lookup features do not upload audio file contents."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "text.magnifyingglass",
+                        title: "Lookup sends search details",
+                        description: "MusicBrainz, iTunes, and LRCLIB searches may use metadata such as title, artist, album, track number, duration, identifiers, links, lyrics, or text you enter."
+                    ),
+                    WelcomeSplashRowContent(
+                        symbol: "network",
+                        title: "External services",
+                        description: "Lookups may contact MusicBrainz, Apple iTunes Search API, Apple artwork CDN, LRCLIB, or related services."
+                    )
+                ]
+            )
         }
     }
 
-    private var platformDeviceName: String {
+    static var domainSummary: String {
+        (NetworkServiceDisclosure.MusicBrainz.domains +
+            NetworkServiceDisclosure.ITunesArtwork.domains +
+            NetworkServiceDisclosure.LRCLIB.domains)
+            .joined(separator: "  ")
+    }
+
+    private static var platformDeviceName: String {
         #if os(macOS)
         "your Mac"
         #else
@@ -226,7 +188,7 @@ private struct WelcomePage: View {
         #endif
     }
 
-    private var platformName: String {
+    private static var platformName: String {
         #if os(macOS)
         "macOS"
         #else
@@ -234,341 +196,11 @@ private struct WelcomePage: View {
         #endif
     }
 
-    private var platformNativeSymbol: String {
+    private static var platformNativeSymbol: String {
         #if os(macOS)
         "macwindow"
         #else
         "ipad"
         #endif
-    }
-}
-
-private struct WelcomeIntroRow: View {
-    let symbol: String
-    let title: String
-    let description: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 18) {
-            Image(systemName: symbol)
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 30, height: 30)
-                .padding(.top, 2)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.system(size: 18, weight: .semibold))
-
-                Text(description)
-                    .font(.system(size: 15))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.leading, 18)
-    }
-}
-
-private struct FeaturesPage: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 26) {
-            PageHeader(
-                title: "What You Can Do",
-                subtitle: "Bring in tracks, inspect tags, make precise changes, and save when you're ready."
-            )
-
-            GroupBox {
-                VStack(alignment: .leading, spacing: 23) {
-                    WelcomeFeatureRow(
-                        symbol: "music.note.list",
-                        title: "Choose one-time or watched sources",
-                        description: "Use Current Session for one-off work, or add watched folders for later."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "slider.horizontal.3",
-                        title: "Inspect and edit metadata",
-                        description: "Review tags, compare selections, and check raw metadata before saving."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "square.stack.3d.down.right",
-                        title: "Use batch utilities",
-                        description: "Reorder files, renumber tracks, copy paths, reveal files, or clear tags."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "photo.on.rectangle.angled",
-                        title: "Work with artwork",
-                        description: "Replace, remove, preview, and apply album artwork from the inspector."
-                    )
-                }
-                .padding(.vertical, 20)
-            }
-        }
-        .padding(.top, 8)
-    }
-}
-
-private struct MusicBrainzPage: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 26) {
-            PageHeader(
-                title: "Match Metadata with MusicBrainz",
-                subtitle: "Search releases and tracks, compare the candidates, and apply the details you choose."
-            )
-
-            GroupBox {
-                VStack(alignment: .leading, spacing: 24) {
-                    WelcomeFeatureRow(
-                        symbol: "magnifyingglass",
-                        title: "Search from selected files",
-                        description: "Start with existing track metadata, or enter a MusicBrainz search manually."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "list.bullet.rectangle",
-                        title: "Review before applying",
-                        description: "Check candidate release and track information before it changes your files."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "square.and.arrow.down",
-                        title: "Apply metadata when ready",
-                        description: "Write matched titles, artists, album details, dates, and identifiers."
-                    )
-                }
-                .padding(.vertical, 22)
-            }
-        }
-        .padding(.top, 8)
-    }
-}
-
-private struct ArtworkPage: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 26) {
-            PageHeader(
-                title: "Find Album Artwork",
-                subtitle: "Use iTunes artwork lookup to find covers, preview them, and apply the selected image."
-            )
-
-            GroupBox {
-                VStack(alignment: .leading, spacing: 24) {
-                    WelcomeFeatureRow(
-                        symbol: "magnifyingglass.circle",
-                        title: "Find covers online",
-                        description: "Search from album details, an iTunes Album ID, or your own artwork search terms."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "rectangle.on.rectangle",
-                        title: "Preview the result",
-                        description: "Compare available artwork before choosing what to use."
-                    )
-
-                    WelcomeFeatureRow(
-                        symbol: "checkmark.rectangle.stack",
-                        title: "Apply to selected files",
-                        description: "Save selected artwork into supported audio files with your metadata edits."
-                    )
-                }
-                .padding(.vertical, 22)
-            }
-        }
-        .padding(.top, 8)
-    }
-}
-
-private struct NetworkPrivacyPage: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            PageHeader(
-                title: "Privacy & Network Access",
-                subtitle: "AudioMator edits files locally. Online services are contacted only when you use lookup features."
-            )
-
-            GroupBox {
-                VStack(alignment: .leading, spacing: 20) {
-                    PrivacyRow(
-                        symbol: "internaldrive",
-                        title: "Your audio stays local",
-                        description: "AudioMator reads and writes the files you choose. Lookup features do not upload audio file contents."
-                    )
-
-                    PrivacyRow(
-                        symbol: "text.magnifyingglass",
-                        title: "Lookup sends search details",
-                        description: "MusicBrainz, iTunes, and LRCLIB searches may use metadata such as title, artist, album, track number, duration, identifiers, links, or text you enter."
-                    )
-
-                    PrivacyRow(
-                        symbol: "network",
-                        title: "External services",
-                        description: "Lookups may contact MusicBrainz, Apple iTunes Search API, Apple artwork CDN, LRCLIB, or related services."
-                    )
-
-                    Text(domainSummary)
-                        .font(.system(size: 13, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .padding(.leading, 66)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .padding(.vertical, 20)
-            }
-        }
-        .padding(.top, 8)
-    }
-
-    private var domainSummary: String {
-        (NetworkServiceDisclosure.MusicBrainz.domains +
-            NetworkServiceDisclosure.ITunesArtwork.domains +
-            NetworkServiceDisclosure.LRCLIB.domains)
-            .joined(separator: "  ")
-    }
-}
-
-private struct PageHeader: View {
-    let title: String
-    let subtitle: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            AppIconHero()
-                .padding(.top, 4)
-
-            VStack(alignment: .leading, spacing: 12) {
-                Text(title)
-                    .font(.system(size: 35, weight: .semibold))
-
-                Text(subtitle)
-                    .font(.system(size: 17))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-}
-
-private struct WelcomeFeatureRow: View {
-    let symbol: String
-    let title: String
-    let description: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 18) {
-            Image(systemName: symbol)
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 30, height: 30)
-                .padding(.top, 2)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.system(size: 18, weight: .semibold))
-
-                Text(description)
-                    .font(.system(size: 15))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.leading, 18)
-    }
-}
-
-private struct PrivacyRow: View {
-    let symbol: String
-    let title: String
-    let description: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 18) {
-            Image(systemName: symbol)
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 30, height: 30)
-                .padding(.top, 2)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.system(size: 18, weight: .semibold))
-
-                Text(description)
-                    .font(.system(size: 15))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.leading, 18)
-    }
-}
-
-private struct GlassActionButtonStyle: ButtonStyle {
-    var isProminent: Bool = false
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.system(size: 15, weight: .semibold))
-            .foregroundStyle(foregroundColor)
-            .frame(minWidth: 108)
-            .padding(.horizontal, 22)
-            .padding(.vertical, 12)
-            .background(background(configuration: configuration))
-            .overlay(border(configuration: configuration))
-            .clipShape(Capsule(style: .continuous))
-            .shadow(color: shadowColor(configuration: configuration), radius: 10, x: 0, y: 6)
-            .scaleEffect(configuration.isPressed ? 0.985 : 1)
-            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
-    }
-
-    private var foregroundColor: Color {
-        isProminent ? .white : Color.primary.opacity(0.82)
-    }
-
-    @ViewBuilder
-    private func background(configuration: Configuration) -> some View {
-        if isProminent {
-            Capsule(style: .continuous)
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            Color.accentColor.opacity(configuration.isPressed ? 0.82 : 0.94),
-                            Color.accentColor.opacity(configuration.isPressed ? 0.66 : 0.80)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-                .background(.ultraThinMaterial, in: Capsule(style: .continuous))
-        } else {
-            Capsule(style: .continuous)
-                .fill(.regularMaterial)
-                .opacity(configuration.isPressed ? 0.88 : 1)
-        }
-    }
-
-    @ViewBuilder
-    private func border(configuration: Configuration) -> some View {
-        Capsule(style: .continuous)
-            .strokeBorder(
-                isProminent
-                    ? Color.white.opacity(configuration.isPressed ? 0.18 : 0.26)
-                    : Color.primary.opacity(configuration.isPressed ? 0.10 : 0.14),
-                lineWidth: 1
-            )
-    }
-
-    private func shadowColor(configuration: Configuration) -> Color {
-        isProminent
-            ? Color.accentColor.opacity(configuration.isPressed ? 0.14 : 0.22)
-            : Color.black.opacity(configuration.isPressed ? 0.04 : 0.08)
     }
 }


### PR DESCRIPTION
## Summary

This PR rewrites the welcome/onboarding implementation while keeping the existing visual design and page flow intact.

The welcome content is now shared as structured page data, with separate renderers for macOS and iPadOS so platform-specific behavior stays isolated. The macOS welcome view now uses a dedicated implementation with a fixed welcome-window size, native scrolling, safe-area bars, and ScrollEdgeEffect support. The iPadOS onboarding path remains separate and keeps the existing SwiftUI behavior.

The online metadata page and privacy disclosure have also been updated for LRCLIB. LRCLIB is now presented alongside MusicBrainz and iTunes as an online metadata source, and the privacy/network copy includes LRCLIB lookup behavior and `lrclib.net`.

## Changes

- Split welcome rendering into shared content plus platform-specific views.
- Added a dedicated macOS welcome view implementation.
- Preserved the existing welcome page layout, hierarchy, spacing intent, and button styling.
- Added top and bottom scroll-edge support for the macOS welcome flow.
- Reduced excess scroll content padding on shorter welcome pages.
- Kept iPadOS onboarding behavior isolated from macOS changes.
- Updated welcome copy to mention LRCLIB as a first-class online metadata source.
- Updated privacy/network disclosure copy and domain summary for LRCLIB.