### PR TITLE
Add albumID and trackID generator for MuseAmp

### DIFF
--- a/AudioMator/Domain/MuseAmp/MuseAmpCommentIDGenerator.swift
+++ b/AudioMator/Domain/MuseAmp/MuseAmpCommentIDGenerator.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+let museAmpSupportEnabledDefaultsKey = "museAmpSupportEnabled"
+
+struct MuseAmpTrackIdentity: Hashable {
+    var album: String
+    var albumArtist: String
+    var trackKey: String
+
+    init(album: String, albumArtist: String, trackKey: String) {
+        self.album = album
+        self.albumArtist = albumArtist
+        self.trackKey = trackKey
+    }
+}
+
+struct MuseAmpCommentID: Equatable {
+    var albumID: String
+    var trackID: String
+    var version: Int
+
+    var commentText: String {
+        MuseAmpCommentIDGenerator.commentText(albumID: albumID, trackID: trackID, version: version)
+    }
+}
+
+enum MuseAmpCommentIDGenerator {
+    static let currentVersion = 1
+
+    static func commentText(albumID: String, trackID: String, version: Int = currentVersion) -> String {
+        "{\"albumID\":\"\(albumID)\",\"trackID\":\"\(trackID)\",\"v\":\(version)}"
+    }
+
+    static func assignments(for tracks: [MuseAmpTrackIdentity]) -> [MuseAmpCommentID] {
+        var albumIDsByKey: [AlbumKey: String] = [:]
+        var usedIDs = Set<String>()
+
+        return tracks.map { track in
+            let albumKey = AlbumKey(album: track.album, albumArtist: track.albumArtist)
+            let albumID = albumIDsByKey[albumKey] ?? {
+                let id = uniqueNumericID(for: "album", key: albumKey.stableKey, usedIDs: &usedIDs)
+                albumIDsByKey[albumKey] = id
+                return id
+            }()
+
+            let trackID = uniqueNumericID(
+                for: "track",
+                key: track.stableTrackKey(albumKey: albumKey),
+                usedIDs: &usedIDs
+            )
+
+            return MuseAmpCommentID(albumID: albumID, trackID: trackID, version: currentVersion)
+        }
+    }
+
+    static func numericID(for namespace: String, key: String, salt: UInt64 = 0) -> String {
+        var hasher = FNV1a64()
+        hasher.append(namespace)
+        hasher.append("\u{1F}")
+        hasher.append(key)
+        hasher.append("\u{1F}")
+        hasher.append(String(salt))
+        return String(hasher.finalize())
+    }
+
+    private static func uniqueNumericID(for namespace: String, key: String, usedIDs: inout Set<String>) -> String {
+        var salt: UInt64 = 0
+
+        while true {
+            let id = numericID(for: namespace, key: key, salt: salt)
+            if usedIDs.insert(id).inserted {
+                return id
+            }
+            salt += 1
+        }
+    }
+}
+
+private struct AlbumKey: Hashable {
+    var album: String
+    var albumArtist: String
+
+    var stableKey: String {
+        "\(album)\u{1F}\(albumArtist)"
+    }
+}
+
+private extension MuseAmpTrackIdentity {
+    func stableTrackKey(albumKey: AlbumKey) -> String {
+        "\(albumKey.stableKey)\u{1F}\(trackKey)"
+    }
+}
+
+private struct FNV1a64 {
+    private var hash: UInt64 = 14_695_981_039_346_656_037
+
+    mutating func append(_ string: String) {
+        for byte in string.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+    }
+
+    func finalize() -> UInt64 {
+        hash == 0 ? 1 : hash
+    }
+}

--- a/AudioMator/Features/Main/ViewModels/AudioViewModel+MetadataWrite.swift
+++ b/AudioMator/Features/Main/ViewModels/AudioViewModel+MetadataWrite.swift
@@ -826,6 +826,86 @@ extension AudioViewModel {
         )
     }
 
+    func createMuseAmpIDs(for targetFiles: [AudioFile]) {
+        guard metadataSaveProgress == nil else { return }
+
+        let targetFiles = targetFiles
+        guard !targetFiles.isEmpty else { return }
+
+        let assignments = MuseAmpCommentIDGenerator.assignments(
+            for: targetFiles.map { file in
+                MuseAmpTrackIdentity(
+                    album: file.album,
+                    albumArtist: file.albumArtist,
+                    trackKey: file.url.path
+                )
+            }
+        )
+
+        beginMetadataSaveProgress(
+            title: "Creating MuseAmp IDs",
+            subtitle: "Preparing \(targetFiles.count) files...",
+            totalUnitCount: targetFiles.count
+        )
+
+        Task(priority: .userInitiated) {
+            var summary = BatchMetadataWriteSummary(totalTargets: targetFiles.count)
+
+            for (index, pair) in zip(targetFiles, assignments).enumerated() {
+                let file = pair.0
+                let museAmpID = pair.1
+
+                self.updateMetadataSaveProgress(
+                    subtitle: file.url.lastPathComponent,
+                    completedUnitCount: index
+                )
+
+                var edit = SingleFileEditModel(from: file)
+                edit.comment = museAmpID.commentText
+
+                let result = await self.persistMetadataEdit(
+                    edit,
+                    to: file,
+                    syncInspectorAfterReload: false
+                )
+
+                switch result {
+                case .success(let success):
+                    summary.succeeded += 1
+                    summary.allSuccessfulFilesRefreshed = summary.allSuccessfulFilesRefreshed && success.didRefreshFileModel
+
+                    if !success.warnings.isEmpty {
+                        summary.warningIssues.append(
+                            BatchMetadataWriteIssue(
+                                fileName: file.url.lastPathComponent,
+                                messages: success.warnings
+                            )
+                        )
+                    }
+                case .failure(let reason):
+                    summary.failureIssues.append(
+                        BatchMetadataWriteIssue(
+                            fileName: file.url.lastPathComponent,
+                            messages: [reason]
+                        )
+                    )
+                }
+            }
+
+            self.updateMetadataSaveProgress(
+                subtitle: "Finishing...",
+                completedUnitCount: targetFiles.count
+            )
+            self.endMetadataSaveProgress()
+
+            if summary.failureIssues.isEmpty && summary.allSuccessfulFilesRefreshed {
+                self.updateEditForSelection()
+            }
+
+            self.presentBatchMetadataWriteSummary(summary)
+        }
+    }
+
     private func beginMetadataSaveProgress(
         title: String,
         subtitle: String,

--- a/AudioMator/Features/Main/Views/ContentPane.swift
+++ b/AudioMator/Features/Main/Views/ContentPane.swift
@@ -17,7 +17,10 @@ struct ContentPane: View {
     let isInspectorVisible: Bool
     let onToggleInspector: () -> Void
 
+    @AppStorage(museAmpSupportEnabledDefaultsKey) private var isMuseAmpSupportEnabled: Bool = false
+
     @State private var isEraseAllTagsConfirmPresented: Bool = false
+    @State private var isMuseAmpIDConfirmPresented: Bool = false
     @State private var isClearListConfirmPresented: Bool = false
 
     private var currentSidebarSelection: SidebarSelection {
@@ -146,7 +149,10 @@ struct ContentPane: View {
                     onCopySelectedFilePaths: copySelectedFilePaths,
                     onCopySelectedFileNames: copySelectedFileNames,
                     onFindSelectedFileInMusicBrainz: onFindSelectedFileInMusicBrainz,
-                    onRequestEraseAllTags: { isEraseAllTagsConfirmPresented = true }
+                    onRequestCreateMuseAmpIDs: { isMuseAmpIDConfirmPresented = true },
+                    onRequestEraseAllTags: { isEraseAllTagsConfirmPresented = true },
+                    isMuseAmpSupportEnabled: isMuseAmpSupportEnabled,
+                    isMuseAmpIDCreationEnabled: viewModel.metadataSaveProgress == nil
                 )
                 .onChange(of: state.selectedAudioIDs) { _, newSelection in
                     viewModel.selectedAudioIDs = newSelection
@@ -163,6 +169,18 @@ struct ContentPane: View {
                     viewModel.selectedAudioIDs = state.selectedAudioIDs
                     viewModel.updateEditForSelection()
                     syncCustomOrderWithFiles()
+                }
+                .confirmationDialog(
+                    "Create MuseAmp IDs?",
+                    isPresented: $isMuseAmpIDConfirmPresented,
+                    titleVisibility: .visible
+                ) {
+                    Button("Create IDs", role: .destructive) {
+                        createMuseAmpIDsForSelectedFiles()
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This replaces the Comment field on the selected files with MuseAmp ID data, then saves the files.")
                 }
                 .confirmationDialog(
                     "Erase all metadata tags?",
@@ -376,6 +394,10 @@ struct ContentPane: View {
 
     private func clearAllMetadataForSelectedFiles() {
         viewModel.eraseAllMetadata(selectedFiles)
+    }
+
+    private func createMuseAmpIDsForSelectedFiles() {
+        viewModel.createMuseAmpIDs(for: selectedFiles)
     }
 
     private func clearFileList() {

--- a/AudioMator/Features/Main/Views/MiddleListTable.swift
+++ b/AudioMator/Features/Main/Views/MiddleListTable.swift
@@ -14,7 +14,10 @@ struct MiddleListTable: NSViewRepresentable {
     let onCopySelectedFilePaths: () -> Void
     let onCopySelectedFileNames: () -> Void
     let onFindSelectedFileInMusicBrainz: () -> Void
+    let onRequestCreateMuseAmpIDs: () -> Void
     let onRequestEraseAllTags: () -> Void
+    let isMuseAmpSupportEnabled: Bool
+    let isMuseAmpIDCreationEnabled: Bool
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -262,6 +265,8 @@ extension MiddleListTable {
                     item.isEnabled = hasSelection
                 case #selector(findSelectedFilesInMusicBrainzAction):
                     item.isEnabled = hasSelection
+                case #selector(requestCreateMuseAmpIDsAction):
+                    item.isEnabled = hasSelection && parent.isMuseAmpIDCreationEnabled
                 case #selector(requestEraseAllTagsAction):
                     item.isEnabled = hasSelection
                 default:
@@ -293,6 +298,11 @@ extension MiddleListTable {
         @objc
         private func findSelectedFilesInMusicBrainzAction() {
             parent.onFindSelectedFileInMusicBrainz()
+        }
+
+        @objc
+        private func requestCreateMuseAmpIDsAction() {
+            parent.onRequestCreateMuseAmpIDs()
         }
 
         @objc
@@ -474,6 +484,9 @@ extension MiddleListTable {
             menu.addItem(makeMenuItem(title: "Copy Filename", action: #selector(copySelectedFileNamesAction)))
             menu.addItem(.separator())
             menu.addItem(makeMenuItem(title: "Find in MusicBrainz", action: #selector(findSelectedFilesInMusicBrainzAction)))
+            if parent.isMuseAmpSupportEnabled {
+                menu.addItem(makeMenuItem(title: "Create MuseAmp IDs…", action: #selector(requestCreateMuseAmpIDsAction)))
+            }
             menu.addItem(.separator())
             menu.addItem(makeMenuItem(title: "Erase All Tags…", action: #selector(requestEraseAllTagsAction)))
 
@@ -548,7 +561,10 @@ struct MiddleListTable: View {
     let onCopySelectedFilePaths: () -> Void
     let onCopySelectedFileNames: () -> Void
     let onFindSelectedFileInMusicBrainz: () -> Void
+    let onRequestCreateMuseAmpIDs: () -> Void
     let onRequestEraseAllTags: () -> Void
+    let isMuseAmpSupportEnabled: Bool
+    let isMuseAmpIDCreationEnabled: Bool
 
     var body: some View {
         List {
@@ -579,6 +595,13 @@ struct MiddleListTable: View {
                         Button("Find in MusicBrainz") {
                             selection = [file.id]
                             onFindSelectedFileInMusicBrainz()
+                        }
+                        if isMuseAmpSupportEnabled {
+                            Button("Create MuseAmp IDs") {
+                                selection = [file.id]
+                                onRequestCreateMuseAmpIDs()
+                            }
+                            .disabled(!isMuseAmpIDCreationEnabled)
                         }
                         Button("Erase All Tags", role: .destructive) {
                             selection = [file.id]

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -27,6 +27,7 @@ struct SettingsView: View {
     @AppStorage(WelcomeSplashProgress.completionKey) private var hasCompletedWelcomeSplash: Bool = false
     @AppStorage(WelcomeSplashProgress.completedVersionKey) private var completedWelcomeSplashVersion: Int = 0
     @AppStorage("suppressesUnsavedInspectorDiscardWarning") private var suppressesUnsavedInspectorDiscardWarning: Bool = false
+    @AppStorage(museAmpSupportEnabledDefaultsKey) private var isMuseAmpSupportEnabled: Bool = false
     @AppStorage(settingsSelectedTabDefaultsKey) private var selectedTabRawValue: String = AppSettingsTab.general.rawValue
 
     var body: some View {
@@ -34,6 +35,7 @@ struct SettingsView: View {
             GeneralSettingsTab(
                 showWelcomeScreenOnLaunch: showWelcomeScreenOnLaunchBinding,
                 warnBeforeDiscardingInspectorEdits: warnBeforeDiscardingInspectorEditsBinding,
+                isMuseAmpSupportEnabled: $isMuseAmpSupportEnabled,
                 onShowWelcomeScreen: showWelcomeScreen
             )
             .tabItem {
@@ -386,6 +388,7 @@ private struct IPadLeftListMetadataPreviewRow: View {
 private struct GeneralSettingsTab: View {
     @Binding var showWelcomeScreenOnLaunch: Bool
     @Binding var warnBeforeDiscardingInspectorEdits: Bool
+    @Binding var isMuseAmpSupportEnabled: Bool
     let onShowWelcomeScreen: () -> Void
 
     var body: some View {
@@ -401,6 +404,10 @@ private struct GeneralSettingsTab: View {
                     "Warn Before Discarding Unsaved Inspector Edits",
                     isOn: $warnBeforeDiscardingInspectorEdits
                 )
+            }
+
+            Section("Integrations") {
+                Toggle("Enable MuseAmp Compatibility", isOn: $isMuseAmpSupportEnabled)
             }
         }
         .audiomatorScrollEdgeEffect(.soft, for: .vertical)

--- a/AudioMatorTests/MuseAmpCommentIDGeneratorTests.swift
+++ b/AudioMatorTests/MuseAmpCommentIDGeneratorTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import AudioMator
+
+final class MuseAmpCommentIDGeneratorTests: XCTestCase {
+    func testTracksWithSameAlbumAndAlbumArtistShareAlbumID() {
+        let assignments = MuseAmpCommentIDGenerator.assignments(for: [
+            MuseAmpTrackIdentity(album: "Blue Hour", albumArtist: "The Band", trackKey: "disc1-track1"),
+            MuseAmpTrackIdentity(album: "Blue Hour", albumArtist: "The Band", trackKey: "disc1-track2")
+        ])
+
+        XCTAssertEqual(assignments[0].albumID, assignments[1].albumID)
+        XCTAssertNotEqual(assignments[0].trackID, assignments[1].trackID)
+    }
+
+    func testDifferentAlbumOrAlbumArtistGetsDifferentAlbumID() {
+        let assignments = MuseAmpCommentIDGenerator.assignments(for: [
+            MuseAmpTrackIdentity(album: "Blue Hour", albumArtist: "The Band", trackKey: "1"),
+            MuseAmpTrackIdentity(album: "Blue Hour", albumArtist: "Another Band", trackKey: "2"),
+            MuseAmpTrackIdentity(album: "Red Hour", albumArtist: "The Band", trackKey: "3")
+        ])
+
+        XCTAssertEqual(Set(assignments.map(\.albumID)).count, 3)
+    }
+
+    func testGeneratedIDsAreNumericStrings() {
+        let assignment = MuseAmpCommentIDGenerator.assignments(for: [
+            MuseAmpTrackIdentity(album: "Album", albumArtist: "Artist", trackKey: "track")
+        ])[0]
+
+        XCTAssertTrue(assignment.albumID.allSatisfy(\.isNumber))
+        XCTAssertTrue(assignment.trackID.allSatisfy(\.isNumber))
+    }
+
+    func testCommentTextMatchesMuseAmpPayloadFormat() {
+        XCTAssertEqual(
+            MuseAmpCommentIDGenerator.commentText(albumID: "13868407145376506873", trackID: "4906269179403622017"),
+            "{\"albumID\":\"13868407145376506873\",\"trackID\":\"4906269179403622017\",\"v\":1}"
+        )
+    }
+
+    func testNumericIDIsStableForSameInput() {
+        XCTAssertEqual(
+            MuseAmpCommentIDGenerator.numericID(for: "track", key: "Album\u{1F}Artist\u{1F}1"),
+            MuseAmpCommentIDGenerator.numericID(for: "track", key: "Album\u{1F}Artist\u{1F}1")
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces MuseAmp compatibility to the application, allowing users to generate and save MuseAmp-compatible IDs in the Comment field of audio files. The feature is gated behind a new setting and is integrated into the UI via context menus and dialogs, with full support for batch operations and progress tracking. The implementation includes a robust ID generation mechanism and comprehensive unit tests.

MuseAmp ID Generation and Assignment:

* Added `MuseAmpCommentIDGenerator` and related types to generate stable, unique numeric IDs for albums and tracks, and to format MuseAmp-compatible comment payloads. The generator ensures IDs are unique and consistent, using a custom FNV-1a 64-bit hash. (`AudioMator/Domain/MuseAmp/MuseAmpCommentIDGenerator.swift`)
* Added a batch operation to the `AudioViewModel` for generating and saving MuseAmp IDs to the Comment field of selected files, with progress reporting and summary of results. (`AudioMator/Features/Main/ViewModels/AudioViewModel+MetadataWrite.swift`)

UI Integration:

* Added a toggle in Settings to enable or disable MuseAmp compatibility, and passed this setting through the UI hierarchy. (`AudioMator/Features/Settings/Views/SettingsView.swift`) [[1]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827R30-R38) [[2]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827R391) [[3]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827R408-R411)
* Updated the main content pane and file list views to conditionally show "Create MuseAmp IDs" actions in context menus and confirmation dialogs when the feature is enabled, and to disable the action during ongoing metadata saves. (`AudioMator/Features/Main/Views/ContentPane.swift`, `AudioMator/Features/Main/Views/MiddleListTable.swift`) [[1]](diffhunk://#diff-10c9411da6d4e590fd82d03842ee96d3a51a9841c90ae88a1a43f1c919260cddR20-R23) [[2]](diffhunk://#diff-10c9411da6d4e590fd82d03842ee96d3a51a9841c90ae88a1a43f1c919260cddL149-R155) [[3]](diffhunk://#diff-10c9411da6d4e590fd82d03842ee96d3a51a9841c90ae88a1a43f1c919260cddR173-R184) [[4]](diffhunk://#diff-10c9411da6d4e590fd82d03842ee96d3a51a9841c90ae88a1a43f1c919260cddR399-R402) [[5]](diffhunk://#diff-87f50c233ff8a81befab28dd4ff1284da815e82f213929777ae0f5673c1d860fR17-R20) [[6]](diffhunk://#diff-87f50c233ff8a81befab28dd4ff1284da815e82f213929777ae0f5673c1d860fR268-R269) [[7]](diffhunk://#diff-87f50c233ff8a81befab28dd4ff1284da815e82f213929777ae0f5673c1d860fR303-R307) [[8]](diffhunk://#diff-87f50c233ff8a81befab28dd4ff1284da815e82f213929777ae0f5673c1d860fR487-R489) [[9]](diffhunk://#diff-87f50c233ff8a81befab28dd4ff1284da815e82f213929777ae0f5673c1d860fR564-R567) [[10]](diffhunk://#diff-87f50c233ff8a81befab28dd4ff1284da815e82f213929777ae0f5673c1d860fR599-R605)

Testing:

* Added a new test suite to verify MuseAmp ID assignment logic, ID stability, and payload formatting. (`AudioMatorTests/MuseAmpCommentIDGeneratorTests.swift`)