### PR TITLE
perf: avoid redundant MusicBrainz assignment list rebuilds

### DIFF
--- a/AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzTaggingWorkbenchView.swift
+++ b/AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzTaggingWorkbenchView.swift
@@ -401,6 +401,34 @@ private struct MusicBrainzAssignmentsAppKitList: NSViewRepresentable {
 
     func updateNSView(_ nsView: MusicBrainzWorkbenchContainerView, context: Context) {
         context.coordinator.parent = self
+        let snapshot = Snapshot(
+            assignments: assignments.map { assignment in
+                AssignmentSnapshot(
+                    id: assignment.id,
+                    displayTitle: assignment.fileInput.preferredDisplayTitle,
+                    artist: assignment.fileInput.artist,
+                    album: assignment.fileInput.album,
+                    initialReason: assignment.initialReason,
+                    selectedTrackID: selectedTrackID(assignment),
+                    isDuplicate: isDuplicate(assignment)
+                )
+            },
+            tracks: tracks.map { track in
+                TrackSnapshot(
+                    id: track.id,
+                    number: track.number,
+                    title: track.title,
+                    artistCredit: track.artistCredit,
+                    mediumTitle: track.mediumTitle,
+                    mediumFormat: track.mediumFormat,
+                    mediumPosition: track.mediumPosition,
+                    releaseMediumCount: track.releaseMediumCount
+                )
+            },
+            isApplying: isApplying
+        )
+        guard snapshot != context.coordinator.lastSnapshot else { return }
+        context.coordinator.lastSnapshot = snapshot
 
         var views: [NSView] = []
         for (index, assignment) in assignments.enumerated() {
@@ -421,8 +449,36 @@ private struct MusicBrainzAssignmentsAppKitList: NSViewRepresentable {
         nsView.replaceArrangedSubviews(with: views)
     }
 
+    struct Snapshot: Equatable {
+        let assignments: [AssignmentSnapshot]
+        let tracks: [TrackSnapshot]
+        let isApplying: Bool
+    }
+
+    struct AssignmentSnapshot: Equatable {
+        let id: String
+        let displayTitle: String
+        let artist: String
+        let album: String
+        let initialReason: String?
+        let selectedTrackID: String?
+        let isDuplicate: Bool
+    }
+
+    struct TrackSnapshot: Equatable {
+        let id: String
+        let number: String
+        let title: String
+        let artistCredit: String
+        let mediumTitle: String
+        let mediumFormat: String
+        let mediumPosition: Int
+        let releaseMediumCount: Int
+    }
+
     final class Coordinator: NSObject {
         var parent: MusicBrainzAssignmentsAppKitList
+        var lastSnapshot: Snapshot?
 
         init(parent: MusicBrainzAssignmentsAppKitList) {
             self.parent = parent


### PR DESCRIPTION
Cache an Equatable snapshot of the assignment rows, selectable release tracks, and applying state in the macOS Review & Apply Tags AppKit bridge. Return early when a SwiftUI update does not change anything rendered by the assignment list.

MusicBrainz recording-detail publications previously caused every row and popup menu to be recreated on the main thread. With 31 populated files and 31 release tracks, each publication rebuilt 31 popups and 992 menu items. Equivalent profile runs reduced the median update from 578.9 ms to 11.6 ms and potential hangs from 24 to 0, while real assignment changes still trigger a rebuild.

Preserve selection behavior, duplicate detection, displayed metadata, apply-state disabling, and the existing metadata write pipeline. This change is macOS-only and does not alter the iTunes workbench.

Verified with:

- xcodebuild -project AudioMator.xcodeproj -scheme AudioMator -configuration Debug -destination platform=macOS -derivedDataPath .deriveddata-codex CODE_SIGNING_ALLOWED=NO -only-testing:AudioMatorTests/OnlineMetadataPlanSnapshotTests test

- swift test --filter AudioMatorCoreLogicTests

- bash scripts/codex-build.sh --force