### PR TITLE
Welcom splash screen revamp

### DIFF
--- a/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
@@ -56,7 +56,6 @@ struct MacWelcomeSplashView: View {
         .audiomatorScrollEdgeEffect(.soft, for: .vertical)
         .frame(width: 750, height: 700)
         .background(MacWelcomeWindowConfigurator())
-        .animation(.easeInOut(duration: 0.18), value: currentPage)
     }
 
     private func advance() {

--- a/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
@@ -28,7 +28,6 @@ struct MacWelcomeSplashView: View {
         ScrollView(.vertical) {
             MacWelcomeSplashPageView(
                 content: currentPage.content,
-                fileAccessGrantPath: fileAccessGrantPath,
                 fileAccessErrorMessage: fileAccessErrorMessage
             )
                 .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -47,7 +46,8 @@ struct MacWelcomeSplashView: View {
                 onQuit: onQuit,
                 onBack: retreat,
                 onSkip: advance,
-                onContinue: continueFromCurrentPage
+                onContinue: continueFromCurrentPage,
+                hasFileAccessGrant: fileAccessGrantPath != nil
             )
             .padding(.horizontal, 30)
             .padding(.top, 14)
@@ -94,65 +94,102 @@ struct MacWelcomeSplashView: View {
 
 private struct MacWelcomeSplashPageView: View {
     let content: WelcomeSplashPageContent
-    let fileAccessGrantPath: String?
     let fileAccessErrorMessage: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: content.page == .welcome ? 28 : 26) {
             MacWelcomeSplashHeader(title: content.title, subtitle: content.subtitle)
 
-            GroupBox {
-                VStack(alignment: .leading, spacing: content.page == .features ? 23 : 24) {
-                    ForEach(content.rows) { row in
-                        MacWelcomeSplashRow(row: row)
-                    }
+            if content.page == .fileAccess {
+                MacWelcomeFileAccessExplanation()
+            } else {
+                GroupBox {
+                    VStack(alignment: .leading, spacing: content.page == .features ? 23 : 24) {
+                        ForEach(content.rows) { row in
+                            MacWelcomeSplashRow(row: row)
+                        }
 
-                    if content.page == .privacy {
-                        Text(WelcomeSplashPage.domainSummary)
-                            .font(.system(size: 13, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .padding(.leading, 66)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if content.page == .privacy {
+                            Text(WelcomeSplashPage.domainSummary)
+                                .font(.system(size: 13, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .padding(.leading, 66)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
+                    .padding(.vertical, content.page == .features || content.page == .privacy ? 20 : 22)
                 }
-                .padding(.vertical, content.page == .features || content.page == .privacy ? 20 : 22)
             }
 
-            if content.page == .fileAccess {
-                MacWelcomeFileAccessStatus(
-                    grantPath: fileAccessGrantPath,
-                    errorMessage: fileAccessErrorMessage
-                )
+            if content.page == .fileAccess, let fileAccessErrorMessage {
+                Text(fileAccessErrorMessage)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(.top, content.topPadding)
     }
 }
 
-private struct MacWelcomeFileAccessStatus: View {
-    let grantPath: String?
-    let errorMessage: String?
-
+private struct MacWelcomeFileAccessExplanation: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            if let grantPath {
-                Label {
-                    Text(grantPath)
-                        .textSelection(.enabled)
-                } icon: {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                }
-                .font(.callout)
-            }
+        GroupBox {
+            VStack(alignment: .leading, spacing: 22) {
+                explanationSection(
+                    title: String(localized: "Why folder access is required")
+                ) {
+                    Text(
+                        String(
+                            localized: "Before saving, AudioMator checks that the file has not changed. It then writes the update to a temporary file in the same folder, replaces the original, and reloads the saved file."
+                        )
+                    )
 
-            if let errorMessage {
-                Text(errorMessage)
-                    .font(.callout)
-                    .foregroundStyle(.red)
+                    Text(
+                        String(
+                            localized: "Because the temporary file must be created beside the original, macOS requires access to the containing folder. Permission for an individual audio file is not enough."
+                        )
+                    )
+                }
+
+                Divider()
+
+                explanationSection(
+                    title: String(localized: "Authorize now, or when needed")
+                ) {
+                    Text(
+                        String(
+                            localized: "If you authorize a folder now, AudioMator remembers that permission for later saves inside it. Authorizing does not save or change any file."
+                        )
+                    )
+
+                    Text(
+                        String(
+                            localized: "You can skip this step. When a save needs access, AudioMator will ask for the exact containing folder."
+                        )
+                    )
+                }
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 22)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func explanationSection<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 10) {
+                content()
+            }
+            .font(.system(size: 15))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 
@@ -217,6 +254,7 @@ private struct MacWelcomeSplashButtonBar: View {
     let onBack: () -> Void
     let onSkip: () -> Void
     let onContinue: () -> Void
+    let hasFileAccessGrant: Bool
 
     var body: some View {
         HStack {
@@ -233,14 +271,26 @@ private struct MacWelcomeSplashButtonBar: View {
             Spacer()
 
             if currentPage == .fileAccess {
-                Button("Skip", action: onSkip)
+                Button("Not Now", action: onSkip)
                     .buttonStyle(MacWelcomeGlassButtonStyle())
             }
 
-            Button(currentPage.next == nil ? "Get Started" : "Continue", action: onContinue)
+            Button(primaryButtonTitle, action: onContinue)
                 .buttonStyle(MacWelcomeGlassButtonStyle(isProminent: true))
                 .keyboardShortcut(.defaultAction)
         }
+    }
+
+    private var primaryButtonTitle: LocalizedStringKey {
+        if currentPage.next == nil {
+            return "Get Started"
+        }
+
+        if currentPage == .fileAccess, !hasFileAccessGrant {
+            return "Authorize Folder…"
+        }
+
+        return "Continue"
     }
 }
 

--- a/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/MacWelcomeSplashView.swift
@@ -107,14 +107,6 @@ private struct MacWelcomeSplashPageView: View {
                         ForEach(content.rows) { row in
                             MacWelcomeSplashRow(row: row)
                         }
-
-                        if content.page == .privacy {
-                            Text(WelcomeSplashPage.domainSummary)
-                                .font(.system(size: 13, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .padding(.leading, 66)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
                     }
                     .padding(.vertical, content.page == .features || content.page == .privacy ? 20 : 22)
                 }

--- a/AudioMator/Features/Welcome/Views/SwiftUIWelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/SwiftUIWelcomeSplashView.swift
@@ -98,14 +98,6 @@ private struct WelcomeSplashPageView: View {
                     ForEach(content.rows) { row in
                         WelcomeSplashRow(row: row)
                     }
-
-                    if content.page == .privacy {
-                        Text(WelcomeSplashPage.domainSummary)
-                            .font(.system(size: 13, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .padding(.leading, 66)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
                 }
                 .padding(.vertical, content.page == .features || content.page == .privacy ? 20 : 22)
             }

--- a/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
@@ -80,8 +80,7 @@ enum WelcomeSplashPage: Int, CaseIterable {
                         title: "Feels native on \(Self.platformName)",
                         description: "Uses familiar windows, sheets, and inspectors."
                     )
-                ],
-                topPadding: 0
+                ]
             )
         case .features:
             WelcomeSplashPageContent(

--- a/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
@@ -115,33 +115,11 @@ enum WelcomeSplashPage: Int, CaseIterable {
         case .fileAccess:
             WelcomeSplashPageContent(
                 page: self,
-                title: String(localized: "Allow Safe File Saving"),
+                title: String(localized: "Protect Your Files While Saving"),
                 subtitle: String(
-                    localized: "AudioMator follows the macOS App Sandbox and only changes files in locations you authorize."
+                    localized: "AudioMator uses transactional saves to reduce the chance that a failed operation leaves an audio file partially written."
                 ),
-                rows: [
-                    WelcomeSplashRowContent(
-                        symbol: "lock.shield",
-                        title: String(localized: "Apple protects your files"),
-                        description: String(
-                            localized: "Choosing individual files allows access to those files, but not permission to create a verified copy beside them."
-                        )
-                    ),
-                    WelcomeSplashRowContent(
-                        symbol: "doc.on.doc",
-                        title: String(localized: "Safe saves use a nearby copy"),
-                        description: String(
-                            localized: "AudioMator writes and verifies a temporary copy before replacing the original audio file."
-                        )
-                    ),
-                    WelcomeSplashRowContent(
-                        symbol: "folder.badge.plus",
-                        title: String(localized: "Choose one trusted folder"),
-                        description: String(
-                            localized: "Allow your user folder now, or choose another folder that contains the audio files you edit."
-                        )
-                    )
-                ]
+                rows: []
             )
         #endif
         case .onlineMetadata:

--- a/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
+++ b/AudioMator/Features/Welcome/Views/WelcomeSplashView.swift
@@ -194,14 +194,6 @@ enum WelcomeSplashPage: Int, CaseIterable {
         }
     }
 
-    static var domainSummary: String {
-        (NetworkServiceDisclosure.MusicBrainz.domains +
-            NetworkServiceDisclosure.iTunesArtwork.domains +
-            NetworkServiceDisclosure.LRCLIB.domains +
-            NetworkServiceDisclosure.SoftwareUpdates.domains)
-            .joined(separator: "  ")
-    }
-
     private static var platformDeviceName: String {
         #if os(macOS)
         "your Mac"

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -1200,16 +1200,7 @@
     "Allow Folder Access" : {
 
     },
-    "Allow Safe File Saving" : {
-
-    },
-    "Allow your user folder now, or choose another folder that contains the audio files you edit." : {
-
-    },
     "Any" : {
-
-    },
-    "Apple protects your files" : {
 
     },
     "Applied" : {
@@ -1621,9 +1612,6 @@
     "AudioMator couldn't save access to %lld selected folders." : {
 
     },
-    "AudioMator follows the macOS App Sandbox and only changes files in locations you authorize." : {
-
-    },
     "AudioMator keeps each file's current extension. The template changes only the filename." : {
       "comment" : "Explanatory helper text, warning, or validation copy. Context: filename and metadata conversion workflow. Used around: AudioMator/Features/MetadataFilenameTool/Views/MetadataFilenameRenameSheet.swift:546.",
       "localizations" : {
@@ -1706,7 +1694,13 @@
         }
       }
     },
-    "AudioMator writes and verifies a temporary copy before replacing the original audio file." : {
+    "AudioMator uses transactional saves to reduce the chance that a failed operation leaves an audio file partially written." : {
+
+    },
+    "Authorize Folder…" : {
+
+    },
+    "Authorize now, or when needed" : {
 
     },
     "Auto Apply Best Matches" : {
@@ -1837,6 +1831,12 @@
           }
         }
       }
+    },
+    "Because the temporary file must be created beside the original, macOS requires access to the containing folder. Permission for an individual audio file is not enough." : {
+
+    },
+    "Before saving, AudioMator checks that the file has not changed. It then writes the update to a temporary file in the same folder, replaces the original, and reloads the saved file." : {
+
     },
     "BETA" : {
 
@@ -2603,9 +2603,6 @@
         }
       }
     },
-    "Choose one trusted folder" : {
-
-    },
     "Choose or paste text to preview imported metadata." : {
 
     },
@@ -2731,9 +2728,6 @@
           }
         }
       }
-    },
-    "Choosing individual files allows access to those files, but not permission to create a verified copy beside them." : {
-
     },
     "Clean" : {
       "comment" : "Short UI label. Used around: AudioMator/Domain/AudioFiles/SingleFileEditModel.swift:441, AudioMator/Features/Main/Views/InspectorPane.swift:922, AudioMator/Features/iPad/Views/IPadInspectorView.swift:212.",
@@ -5560,6 +5554,9 @@
           }
         }
       }
+    },
+    "If you authorize a folder now, AudioMator remembers that permission for later saves inside it. Authorizing does not save or change any file." : {
+
     },
     "Ignore" : {
       "comment" : "Button or menu command; translate as an action, usually concise. Used around: AudioMator/Domain/MetadataExchange/MetadataExchange.swift:138, AudioMator/Domain/Rename/FileRenameTemplate.swift:54.",
@@ -8739,6 +8736,9 @@
         }
       }
     },
+    "Not Now" : {
+
+    },
     "Nothing to Preview" : {
 
     },
@@ -9593,6 +9593,9 @@
           }
         }
       }
+    },
+    "Protect Your Files While Saving" : {
+
     },
     "Publisher" : {
       "comment" : "Audio metadata field label; prefer the term users expect in music tag editors. Used around: AudioMator/Domain/UIState/InspectorMetadataField.swift:53, AudioMator/Domain/UIState/MiddleListColumn.swift:55, AudioMator/Domain/MetadataExchange/MetadataExchange.swift:134, AudioMator/Domain/AudioFiles/SingleFileEditModel.swift:326.",
@@ -11072,9 +11075,6 @@
       }
     },
     "Review recent save warnings and failures shown by the save status HUD." : {
-
-    },
-    "Safe saves use a nearby copy" : {
 
     },
     "Same" : {
@@ -14126,6 +14126,9 @@
     "Watched folders stay in the sidebar across launches." : {
 
     },
+    "Why folder access is required" : {
+
+    },
     "Write" : {
       "comment" : "Button or menu command; translate as an action, usually concise. Used around: AudioMator/Domain/MetadataExchange/MetadataExchange.swift:69, AudioMator/Domain/MetadataEditing/AudioMetadataPipeline.swift:49, AudioMator/Domain/Rename/FilenameMetadataTemplate.swift:169, AudioMator/Features/Main/ViewModels/AudioViewModel+Import.swift:32.",
       "localizations" : {
@@ -14254,6 +14257,9 @@
           }
         }
       }
+    },
+    "You can skip this step. When a save needs access, AudioMator will ask for the exact containing folder." : {
+
     },
     "YYYY" : {
 


### PR DESCRIPTION
This pull request refines and simplifies the welcome splash flow for folder access in AudioMator, especially on macOS. The changes focus on improving the user experience and clarity around why folder access is needed, updating button labels, and cleaning up unused code and localization strings.

### User Experience Improvements

* The folder access page (`.fileAccess`) now displays a clear, two-part explanation (`MacWelcomeFileAccessExplanation`) about why folder access is required and reassures users about when and how authorization is used, instead of showing a status component.
* The primary action button on the folder access page now dynamically changes its label to "Authorize Folder…" if access has not been granted, otherwise "Continue", and the skip button is labeled "Not Now". [[1]](diffhunk://#diff-7d46cfd0070b339218000de24ea78b1eb2a7f6e5af3847cecfc0b722395a2e84L236-R285) [[2]](diffhunk://#diff-7d46cfd0070b339218000de24ea78b1eb2a7f6e5af3847cecfc0b722395a2e84L50-R50)
* The title and subtitle for the folder access page have been updated for clarity and reassurance, focusing on file protection and transactional saves. [[1]](diffhunk://#diff-d3852d0f68b6ed0d8bc4b2ad0595c6c42b7456bf727c1a6d148cc24bab00a501L118-R121) [[2]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86R9596-R9598) [[3]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86L1709-R1703)
* The animation for page transitions in `MacWelcomeSplashView` has been removed for a simpler and more stable experience.

### Code and Content Cleanup

* Unused or redundant code and localizations related to the old folder access explanation, privacy section, and related UI have been removed or replaced, including the removal of the `MacWelcomeFileAccessStatus` view and associated localization strings. [[1]](diffhunk://#diff-7d46cfd0070b339218000de24ea78b1eb2a7f6e5af3847cecfc0b722395a2e84L97-L155) [[2]](diffhunk://#diff-8c9a30389d58cf1ac28f1602fcb872d26595f70dc9751d1c0a897da880616889L101-L108) [[3]](diffhunk://#diff-d3852d0f68b6ed0d8bc4b2ad0595c6c42b7456bf727c1a6d148cc24bab00a501L219-L226) [[4]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86R14128-R14130) [[5]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86L2605-L2607) [[6]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86L2734-L2736) [[7]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86L11076-L11078) [[8]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86L1623-L1625) [[9]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86R5557-R5559) [[10]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86R1834-R1839) [[11]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86R14260-R14262) F1411f79L98R98, [[12]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86L1709-R1703) [[13]](diffhunk://#diff-e94ce164fb5c41a20f039450fb414763c2cef1261b519aeee80645427de79b86R9596-R9598)

### Technical Adjustments

* The `fileAccessGrantPath` parameter is no longer passed down to the content view, and the presence of file access is tracked by a boolean (`hasFileAccessGrant`). [[1]](diffhunk://#diff-7d46cfd0070b339218000de24ea78b1eb2a7f6e5af3847cecfc0b722395a2e84L31) [[2]](diffhunk://#diff-7d46cfd0070b339218000de24ea78b1eb2a7f6e5af3847cecfc0b722395a2e84L50-R50) [[3]](diffhunk://#diff-7d46cfd0070b339218000de24ea78b1eb2a7f6e5af3847cecfc0b722395a2e84R248)
* The `topPadding` property is no longer set for the welcome page, simplifying layout logic.

These changes collectively make the welcome experience clearer and more user-friendly, while also cleaning up legacy code and unused strings.