### PR TITLE
Settings Revamp

### DIFF
--- a/AudioMator/App/AudioMatorApp.swift
+++ b/AudioMator/App/AudioMatorApp.swift
@@ -75,7 +75,11 @@ struct AudioMatorApp: App {
         .defaultSize(width: 900, height: 600)
 
         Settings {
-            SettingsView(sharedState: sharedState, saveIssueLogStore: saveIssueLogStore)
+            SettingsView(
+                viewModel: viewModel,
+                sharedState: sharedState,
+                saveIssueLogStore: saveIssueLogStore
+            )
         }
         .defaultSize(width: 700, height: 480)
 

--- a/AudioMator/Features/Main/State/ToolbarButtonOption.swift
+++ b/AudioMator/Features/Main/State/ToolbarButtonOption.swift
@@ -55,7 +55,7 @@ enum ToolbarButtonOption: String, CaseIterable, Identifiable {
         case .cancelEdits:
             return "xmark.circle"
         case .saveEdits:
-            return "square.and.arrow.down"
+            return "checkmark.circle"
         }
     }
 

--- a/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
+++ b/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
@@ -725,7 +725,7 @@ final class AudioViewModel: ObservableObject {
         #if os(macOS)
         let homeURL = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
         let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = false
+        panel.allowsMultipleSelection = true
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.canCreateDirectories = false
@@ -733,30 +733,45 @@ final class AudioViewModel: ObservableObject {
         panel.title = String(localized: "Allow File Access")
         panel.prompt = String(localized: "Allow")
         panel.message = String(
-            localized: "Select your user folder, or another folder containing the audio files you edit."
+            localized: "Select one or more folders containing the audio files you edit, such as your user folder."
         )
 
-        guard panel.runModal() == .OK, let selectedURL = panel.url?.standardizedFileURL else {
+        guard panel.runModal() == .OK else {
             return .cancelled
         }
 
-        do {
-            let grant = try registerFileAccessGrant(for: selectedURL)
-            return .authorized(path: grant.url.path)
-        } catch {
-            return .failure((error as NSError).localizedDescription)
+        let selectedURLs = panel.urls.map(\.standardizedFileURL)
+        guard !selectedURLs.isEmpty else { return .cancelled }
+
+        var firstGrant: FileAccessGrant?
+        for selectedURL in selectedURLs {
+            do {
+                let grant = try registerFileAccessGrant(for: selectedURL)
+                firstGrant = firstGrant ?? grant
+            } catch {
+                return .failure((error as NSError).localizedDescription)
+            }
         }
+
+        return .authorized(path: firstGrant?.url.path ?? selectedURLs[0].path)
         #else
         return .failure(String(localized: "Folder preauthorization is available on macOS only."))
         #endif
     }
 
     func removeFileAccessGrant(id: UUID) {
-        guard fileAccessGrants.contains(where: { $0.id == id }) else { return }
+        removeFileAccessGrants(ids: [id])
+    }
 
-        securityScopedFileAccessGrantURLs.removeValue(forKey: id)?
-            .stopAccessingSecurityScopedResource()
-        fileAccessGrants.removeAll { $0.id == id }
+    func removeFileAccessGrants(ids: Set<UUID>) {
+        let existingIDs = ids.intersection(fileAccessGrants.map(\.id))
+        guard !existingIDs.isEmpty else { return }
+
+        for id in existingIDs {
+            securityScopedFileAccessGrantURLs.removeValue(forKey: id)?
+                .stopAccessingSecurityScopedResource()
+        }
+        fileAccessGrants.removeAll { existingIDs.contains($0.id) }
         fileAccessGrantStore.saveGrants(fileAccessGrants)
     }
 

--- a/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
+++ b/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
@@ -490,14 +490,21 @@ final class AudioViewModel: ObservableObject {
     }
 
     func removeWatchedFolder(id: UUID) {
-        guard watchedFolders.contains(where: { $0.id == id }) else { return }
+        removeWatchedFolders(ids: [id])
+    }
 
-        stopWatchingFolder(id: id)
-        watchedFolders.removeAll { $0.id == id }
-        watchedFolderFiles[id] = nil
-        watchedFolderScanFailureCounts[id] = nil
-        watchedFolderMetadataReadFailureCounts[id] = nil
-        folderScanTokens[id] = nil
+    func removeWatchedFolders(ids: Set<UUID>) {
+        let existingIDs = ids.intersection(watchedFolders.map(\.id))
+        guard !existingIDs.isEmpty else { return }
+
+        for id in existingIDs {
+            stopWatchingFolder(id: id)
+            watchedFolderFiles[id] = nil
+            watchedFolderScanFailureCounts[id] = nil
+            watchedFolderMetadataReadFailureCounts[id] = nil
+            folderScanTokens[id] = nil
+        }
+        watchedFolders.removeAll { existingIDs.contains($0.id) }
 
         persistWatchedFolders()
 

--- a/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
+++ b/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
@@ -751,6 +751,15 @@ final class AudioViewModel: ObservableObject {
         #endif
     }
 
+    func removeFileAccessGrant(id: UUID) {
+        guard fileAccessGrants.contains(where: { $0.id == id }) else { return }
+
+        securityScopedFileAccessGrantURLs.removeValue(forKey: id)?
+            .stopAccessingSecurityScopedResource()
+        fileAccessGrants.removeAll { $0.id == id }
+        fileAccessGrantStore.saveGrants(fileAccessGrants)
+    }
+
     func registerMovedFiles(_ changes: [(id: UUID, oldURL: URL, newURL: URL)]) {
         guard !changes.isEmpty else { return }
 

--- a/AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzTaggingWorkbenchView.swift
+++ b/AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzTaggingWorkbenchView.swift
@@ -666,13 +666,13 @@ private enum MusicBrainzWorkbenchAppKitFactory {
         return label("MusicBrainz: \(number)\(track.title)", font: .systemFont(ofSize: 11), color: .secondaryLabelColor)
     }
 
-    private static func trackOptionTitle(_ track: MusicBrainzReleaseMatchTrack) -> String {
+    nonisolated private static func trackOptionTitle(_ track: MusicBrainzReleaseMatchTrack) -> String {
         let number = track.number.isEmpty ? "" : "\(track.number) "
         let discPrefix = track.releaseMediumCount > 1 ? "Disc \(track.mediumPosition) • " : ""
         return discPrefix + number + track.title
     }
 
-    private static func trackDetailLine(for track: MusicBrainzReleaseMatchTrack) -> String {
+    nonisolated private static func trackDetailLine(for track: MusicBrainzReleaseMatchTrack) -> String {
         [
             track.artistCredit,
             track.mediumFormat.isEmpty ? track.mediumTitle : track.mediumFormat

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -235,14 +235,16 @@ struct FileAccessSettingsTab: View {
     ) -> some View {
         HStack(alignment: .center) {
             Image(systemName: "folder")
+                .foregroundStyle(.primary.opacity(0.65))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(displayName)
+                    .foregroundStyle(.primary.opacity(0.82))
                     .lineLimit(1)
 
                 Text(url.path(percentEncoded: false))
                     .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.secondary.opacity(0.82))
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
@@ -264,6 +266,7 @@ struct FileAccessSettingsTab: View {
                     .labelStyle(.iconOnly)
             }
             .buttonStyle(.borderless)
+            .foregroundStyle(.secondary.opacity(0.82))
             .help(String(localized: "Open Folder"))
         }
         .accessibilityLabel(displayName)

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -96,6 +96,17 @@ struct FileAccessSettingsTab: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
+
+            Spacer()
+
+            Button {
+                PlatformWorkspace.open(grant.url)
+            } label: {
+                Label(String(localized: "Open Folder"), systemImage: "arrow.up.forward")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Open Folder"))
         }
         .contextMenu {
             Button(String(localized: "Remove"), role: .destructive) {

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -9,40 +9,36 @@ struct FileAccessSettingsTab: View {
     @State private var isFileAccessInfoPresented = false
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(String(localized: "File Access"))
-                        .font(.title3.weight(.semibold))
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "File Access"))
+                    .font(.title3.weight(.semibold))
 
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Text(String(localized: "Choose which folders AudioMator can access between launches."))
-                            .foregroundStyle(.secondary)
-
-                        Button {
-                            isFileAccessInfoPresented.toggle()
-                        } label: {
-                            Label(String(localized: "About Folder Access"), systemImage: "info.circle")
-                                .labelStyle(.iconOnly)
-                        }
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(String(localized: "Choose which folders AudioMator can access between launches."))
                         .foregroundStyle(.secondary)
-                        .help(String(localized: "About Folder Access"))
-                        .popover(isPresented: $isFileAccessInfoPresented) {
-                            fileAccessInfoPopover
-                        }
+
+                    Button {
+                        isFileAccessInfoPresented.toggle()
+                    } label: {
+                        Label(String(localized: "About Folder Access"), systemImage: "info.circle")
+                            .labelStyle(.iconOnly)
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .foregroundStyle(.secondary)
+                    .help(String(localized: "About Folder Access"))
+                    .popover(isPresented: $isFileAccessInfoPresented) {
+                        fileAccessInfoPopover
                     }
                 }
-
-                authorizedFoldersList
             }
-            .padding(20)
-            .padding(.bottom, 28)
-            .frame(maxWidth: 760, alignment: .topLeading)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+
+            authorizedFoldersList
         }
-        .audiomatorScrollEdgeEffect(.soft, for: .vertical)
+        .padding(20)
+        .padding(.bottom, 28)
+        .frame(maxWidth: 760, alignment: .topLeading)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
             guard let selectedGrantID, !grantIDs.contains(selectedGrantID) else { return }
@@ -60,47 +56,39 @@ struct FileAccessSettingsTab: View {
 
     private var authorizedFoldersList: some View {
         GroupBox {
-            List(selection: $selectedGrantID) {
+            VStack(spacing: 0) {
                 if viewModel.fileAccessGrants.isEmpty {
                     ContentUnavailableView(
                         String(localized: "No Authorized Folders"),
                         systemImage: "folder",
                         description: Text(String(localized: "Use the add button to grant access to a folder."))
                     )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    ForEach(viewModel.fileAccessGrants) { grant in
-                        folderRow(grant)
-                            .tag(grant.id)
+                    List(selection: $selectedGrantID) {
+                        ForEach(viewModel.fileAccessGrants) { grant in
+                            folderRow(grant)
+                                .tag(grant.id)
+                        }
                     }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, -8)
+                    .padding(.top, 4)
                 }
 
+                Divider()
+
                 folderActions
+                    .frame(height: 20)
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .padding(.horizontal, -8)
-            .padding(.top, 4)
         }
         .frame(height: authorizedFoldersListHeight)
         .onDeleteCommand(perform: removeSelectedFolder)
     }
 
     private var authorizedFoldersListHeight: CGFloat {
-        let folderRowHeight: CGFloat = 39
-        let actionsHeight: CGFloat = 24
-        let containerVerticalInsets: CGFloat = 12
-        let folderContentHeight: CGFloat
-
-        if viewModel.fileAccessGrants.isEmpty {
-            folderContentHeight = 96
-        } else {
-            folderContentHeight = CGFloat(viewModel.fileAccessGrants.count) * folderRowHeight
-        }
-
-        return min(
-            folderContentHeight + actionsHeight + containerVerticalInsets,
-            352
-        )
+        280
     }
 
     private var fileAccessInfoPopover: some View {
@@ -183,6 +171,7 @@ struct FileAccessSettingsTab: View {
             .help(String(localized: "Add Folder"))
 
             Divider()
+                .frame(height: 16)
 
             Button(action: removeSelectedFolder) {
                 Label(String(localized: "Remove Selected Folder"), systemImage: "minus")

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -78,6 +78,8 @@ struct FileAccessSettingsTab: View {
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
+            .padding(.horizontal, -8)
+            .padding(.top, 4)
         }
         .frame(height: authorizedFoldersListHeight)
         .onDeleteCommand(perform: removeSelectedFolder)
@@ -86,7 +88,7 @@ struct FileAccessSettingsTab: View {
     private var authorizedFoldersListHeight: CGFloat {
         let folderRowHeight: CGFloat = 39
         let actionsHeight: CGFloat = 24
-        let containerInsets: CGFloat = 12
+        let containerVerticalInsets: CGFloat = 12
         let folderContentHeight: CGFloat
 
         if viewModel.fileAccessGrants.isEmpty {
@@ -96,7 +98,7 @@ struct FileAccessSettingsTab: View {
         }
 
         return min(
-            folderContentHeight + actionsHeight + containerInsets,
+            folderContentHeight + actionsHeight + containerVerticalInsets,
             352
         )
     }
@@ -192,6 +194,7 @@ struct FileAccessSettingsTab: View {
 
             Spacer()
         }
+        .controlSize(.small)
     }
 
     private var authorizationErrorBinding: Binding<Bool> {

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -6,16 +6,43 @@ struct FileAccessSettingsTab: View {
 
     @State private var selectedGrantID: FileAccessGrant.ID?
     @State private var authorizationError: String?
+    @State private var isFileAccessInfoPresented = false
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text(String(localized: "File Access"))
-                .font(.headline)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "File Access"))
+                        .font(.title3.weight(.semibold))
 
-            authorizedFoldersList
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Text(String(localized: "Choose which folders AudioMator can access between launches."))
+                            .foregroundStyle(.secondary)
+
+                        Button {
+                            isFileAccessInfoPresented.toggle()
+                        } label: {
+                            Label(String(localized: "About Folder Access"), systemImage: "info.circle")
+                                .labelStyle(.iconOnly)
+                        }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .foregroundStyle(.secondary)
+                        .help(String(localized: "About Folder Access"))
+                        .popover(isPresented: $isFileAccessInfoPresented) {
+                            fileAccessInfoPopover
+                        }
+                    }
+                }
+
+                authorizedFoldersList
+            }
+            .padding(20)
+            .padding(.bottom, 28)
+            .frame(maxWidth: 760, alignment: .topLeading)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        .padding()
-        .frame(maxWidth: 760, maxHeight: .infinity, alignment: .topLeading)
+        .audiomatorScrollEdgeEffect(.soft, for: .vertical)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
             guard let selectedGrantID, !grantIDs.contains(selectedGrantID) else { return }
@@ -34,13 +61,6 @@ struct FileAccessSettingsTab: View {
     private var authorizedFoldersList: some View {
         GroupBox {
             List(selection: $selectedGrantID) {
-                Text(
-                    String(
-                        localized: "Allow AudioMator to access the folders below between launches."
-                    )
-                )
-                .foregroundStyle(.secondary)
-
                 if viewModel.fileAccessGrants.isEmpty {
                     ContentUnavailableView(
                         String(localized: "No Authorized Folders"),
@@ -64,22 +84,55 @@ struct FileAccessSettingsTab: View {
     }
 
     private var authorizedFoldersListHeight: CGFloat {
-        let descriptionHeight: CGFloat = 26
         let folderRowHeight: CGFloat = 39
         let actionsHeight: CGFloat = 24
         let containerInsets: CGFloat = 12
         let folderContentHeight: CGFloat
 
         if viewModel.fileAccessGrants.isEmpty {
-            folderContentHeight = 72
+            folderContentHeight = 96
         } else {
             folderContentHeight = CGFloat(viewModel.fileAccessGrants.count) * folderRowHeight
         }
 
         return min(
-            descriptionHeight + folderContentHeight + actionsHeight + containerInsets,
+            folderContentHeight + actionsHeight + containerInsets,
             352
         )
+    }
+
+    private var fileAccessInfoPopover: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(String(localized: "Why folder access is required"), systemImage: "info.circle")
+                .font(.headline)
+
+            Text(
+                String(
+                    localized: "AudioMator runs in the macOS App Sandbox. It can read and edit files only in folders you choose."
+                )
+            )
+
+            Text(
+                String(
+                    localized: "If you authorize a folder now, AudioMator remembers that permission for later saves inside it. Authorizing does not save or change any file."
+                )
+            )
+
+            Text(
+                String(
+                    localized: "Removing a folder from this list removes AudioMator's saved access. It does not delete or modify the folder or any files inside it."
+                )
+            )
+
+            Text(
+                String(
+                    localized: "If a folder is moved or renamed, macOS may require you to authorize it again."
+                )
+            )
+            .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(width: 360, alignment: .leading)
     }
 
     private func folderRow(_ grant: FileAccessGrant) -> some View {

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -8,14 +8,13 @@ struct FileAccessSettingsTab: View {
     @State private var authorizationError: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading) {
             Text(String(localized: "File Access"))
-                .font(.title3.weight(.semibold))
+                .font(.headline)
 
             authorizedFoldersList
         }
-        .padding(20)
-        .padding(.bottom, 8)
+        .padding()
         .frame(maxWidth: 760, maxHeight: .infinity, alignment: .topLeading)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
@@ -34,63 +33,59 @@ struct FileAccessSettingsTab: View {
 
     private var authorizedFoldersList: some View {
         GroupBox {
-            VStack(spacing: 0) {
-                List(selection: $selectedGrantID) {
-                    Text(
-                        String(
-                            localized: "Allow AudioMator to access the folders below between launches."
-                        )
+            List(selection: $selectedGrantID) {
+                Text(
+                    String(
+                        localized: "Allow AudioMator to access the folders below between launches."
                     )
-                    .foregroundStyle(.secondary)
-                    .listRowInsets(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
+                )
+                .foregroundStyle(.secondary)
 
-                    if viewModel.fileAccessGrants.isEmpty {
-                        ContentUnavailableView(
-                            String(localized: "No Authorized Folders"),
-                            systemImage: "folder",
-                            description: Text(String(localized: "Use the add button to grant access to a folder."))
-                        )
-                        .listRowInsets(EdgeInsets(top: 12, leading: 10, bottom: 12, trailing: 10))
-                    } else {
-                        ForEach(viewModel.fileAccessGrants) { grant in
-                            folderRow(grant)
-                                .tag(grant.id)
-                                .listRowInsets(EdgeInsets(top: 3, leading: 10, bottom: 3, trailing: 10))
-                        }
+                if viewModel.fileAccessGrants.isEmpty {
+                    ContentUnavailableView(
+                        String(localized: "No Authorized Folders"),
+                        systemImage: "folder",
+                        description: Text(String(localized: "Use the add button to grant access to a folder."))
+                    )
+                } else {
+                    ForEach(viewModel.fileAccessGrants) { grant in
+                        folderRow(grant)
+                            .tag(grant.id)
                     }
                 }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
-                .contentMargins(.horizontal, 0, for: .scrollContent)
-                .contentMargins(.vertical, 0, for: .scrollContent)
-
-                Divider()
 
                 folderActions
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
         }
         .frame(height: authorizedFoldersListHeight)
         .onDeleteCommand(perform: removeSelectedFolder)
     }
 
     private var authorizedFoldersListHeight: CGFloat {
-        let descriptionHeight: CGFloat = 36
-        let toolbarHeight: CGFloat = 29
-        let groupInsets: CGFloat = 18
-        let contentHeight: CGFloat
+        let descriptionHeight: CGFloat = 26
+        let folderRowHeight: CGFloat = 39
+        let actionsHeight: CGFloat = 24
+        let containerInsets: CGFloat = 12
+        let folderContentHeight: CGFloat
 
         if viewModel.fileAccessGrants.isEmpty {
-            contentHeight = 120
+            folderContentHeight = 72
         } else {
-            contentHeight = min(CGFloat(viewModel.fileAccessGrants.count) * 40, 280)
+            folderContentHeight = CGFloat(viewModel.fileAccessGrants.count) * folderRowHeight
         }
 
-        return descriptionHeight + contentHeight + toolbarHeight + groupInsets
+        return min(
+            descriptionHeight + folderContentHeight + actionsHeight + containerInsets,
+            352
+        )
     }
 
     private func folderRow(_ grant: FileAccessGrant) -> some View {
-        Label {
+        HStack(alignment: .center) {
+            Image(systemName: "folder")
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(grant.displayName)
                     .lineLimit(1)
@@ -101,8 +96,6 @@ struct FileAccessSettingsTab: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-        } icon: {
-            Image(systemName: "folder")
         }
         .contextMenu {
             Button(String(localized: "Remove"), role: .destructive) {
@@ -115,41 +108,26 @@ struct FileAccessSettingsTab: View {
     }
 
     private var folderActions: some View {
-        HStack(spacing: 0) {
-            folderActionButton(
-                systemImage: "plus",
-                accessibilityLabel: String(localized: "Add Folder"),
-                action: addFolder
-            )
+        HStack {
+            Button(action: addFolder) {
+                Label(String(localized: "Add Folder"), systemImage: "plus")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Add Folder"))
 
             Divider()
-                .frame(height: 16)
 
-            folderActionButton(
-                systemImage: "minus",
-                accessibilityLabel: String(localized: "Remove Selected Folder"),
-                action: removeSelectedFolder
-            )
+            Button(action: removeSelectedFolder) {
+                Label(String(localized: "Remove Selected Folder"), systemImage: "minus")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
             .disabled(selectedGrantID == nil)
+            .help(String(localized: "Remove Selected Folder"))
 
             Spacer()
         }
-        .padding(.leading, 4)
-        .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
-    }
-
-    private func folderActionButton(
-        systemImage: String,
-        accessibilityLabel: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .frame(width: 28, height: 28)
-        }
-        .buttonStyle(.borderless)
-        .accessibilityLabel(accessibilityLabel)
-        .help(accessibilityLabel)
     }
 
     private var authorizationErrorBinding: Binding<Bool> {

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -1,11 +1,31 @@
 #if os(macOS)
 import SwiftUI
 
+struct WatchedFolderSettingsSelection {
+    var ids: Set<WatchedFolder.ID> = []
+
+    mutating func retainAvailableFolders(_ availableIDs: Set<WatchedFolder.ID>) {
+        ids.formIntersection(availableIDs)
+    }
+
+    mutating func selectNewFolders(
+        previousIDs: Set<WatchedFolder.ID>,
+        currentIDs: Set<WatchedFolder.ID>
+    ) {
+        ids = currentIDs.subtracting(previousIDs)
+    }
+
+    mutating func consumeForRemoval() -> Set<WatchedFolder.ID> {
+        defer { ids.removeAll() }
+        return ids
+    }
+}
+
 struct FileAccessSettingsTab: View {
     @ObservedObject var viewModel: AudioViewModel
 
     @State private var selectedFileAccessGrantIDs: Set<FileAccessGrant.ID> = []
-    @State private var selectedWatchedFolderIDs: Set<WatchedFolder.ID> = []
+    @State private var watchedFolderSelection = WatchedFolderSettingsSelection()
     @State private var authorizationError: String?
     @State private var isFileAccessInfoPresented = false
 
@@ -28,7 +48,7 @@ struct FileAccessSettingsTab: View {
             selectedFileAccessGrantIDs.formIntersection(grantIDs)
         }
         .onChange(of: viewModel.watchedFolders.map(\.id)) { _, folderIDs in
-            selectedWatchedFolderIDs.formIntersection(folderIDs)
+            watchedFolderSelection.retainAvailableFolders(Set(folderIDs))
         }
         .alert(
             String(localized: "Couldn't Add Folder"),
@@ -136,7 +156,7 @@ struct FileAccessSettingsTab: View {
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    List(selection: $selectedWatchedFolderIDs) {
+                    List(selection: $watchedFolderSelection.ids) {
                         ForEach(viewModel.watchedFolders) { folder in
                             watchedFolderRow(folder)
                                 .tag(folder.id)
@@ -219,7 +239,7 @@ struct FileAccessSettingsTab: View {
         )
         .contextMenu {
             Button(String(localized: "Remove"), role: .destructive) {
-                if selectedWatchedFolderIDs.contains(folder.id) {
+                if watchedFolderSelection.ids.contains(folder.id) {
                     removeSelectedWatchedFolders()
                 } else {
                     viewModel.removeWatchedFolder(id: folder.id)
@@ -315,7 +335,7 @@ struct FileAccessSettingsTab: View {
                     .labelStyle(.iconOnly)
             }
             .buttonStyle(.borderless)
-            .disabled(selectedWatchedFolderIDs.isEmpty)
+            .disabled(watchedFolderSelection.ids.isEmpty)
             .help(String(localized: "Remove Selected Folders"))
 
             Spacer()
@@ -348,7 +368,10 @@ struct FileAccessSettingsTab: View {
     private func addWatchedFolders() {
         let existingIDs = Set(viewModel.watchedFolders.map(\.id))
         _ = viewModel.addWatchedFolders()
-        selectedWatchedFolderIDs = Set(viewModel.watchedFolders.map(\.id)).subtracting(existingIDs)
+        watchedFolderSelection.selectNewFolders(
+            previousIDs: existingIDs,
+            currentIDs: Set(viewModel.watchedFolders.map(\.id))
+        )
     }
 
     private func removeSelectedFileAccessFolders() {
@@ -358,9 +381,9 @@ struct FileAccessSettingsTab: View {
     }
 
     private func removeSelectedWatchedFolders() {
-        guard !selectedWatchedFolderIDs.isEmpty else { return }
-        viewModel.removeWatchedFolders(ids: selectedWatchedFolderIDs)
-        selectedWatchedFolderIDs.removeAll()
+        let selectedIDs = watchedFolderSelection.consumeForRemoval()
+        guard !selectedIDs.isEmpty else { return }
+        viewModel.removeWatchedFolders(ids: selectedIDs)
     }
 }
 #endif

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -4,12 +4,44 @@ import SwiftUI
 struct FileAccessSettingsTab: View {
     @ObservedObject var viewModel: AudioViewModel
 
-    @State private var selectedGrantIDs: Set<FileAccessGrant.ID> = []
+    @State private var selectedFileAccessGrantIDs: Set<FileAccessGrant.ID> = []
+    @State private var selectedWatchedFolderIDs: Set<WatchedFolder.ID> = []
     @State private var authorizationError: String?
     @State private var isFileAccessInfoPresented = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                fileAccessSection
+                watchedFoldersSection
+            }
+            .padding(20)
+            .padding(.bottom, 28)
+            .frame(maxWidth: 760, alignment: .topLeading)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .audiomatorScrollEdgeEffect(.soft, for: .vertical)
+        .scrollIndicators(.automatic, axes: .vertical)
+        .scrollBounceBehavior(.basedOnSize)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
+            selectedFileAccessGrantIDs.formIntersection(grantIDs)
+        }
+        .onChange(of: viewModel.watchedFolders.map(\.id)) { _, folderIDs in
+            selectedWatchedFolderIDs.formIntersection(folderIDs)
+        }
+        .alert(
+            String(localized: "Couldn't Add Folder"),
+            isPresented: authorizationErrorBinding
+        ) {
+            Button(String(localized: "OK"), role: .cancel) {}
+        } message: {
+            Text(authorizationError ?? String(localized: "AudioMator couldn't save access to this folder."))
+        }
+    }
+
+    private var fileAccessSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(String(localized: "File Access"))
                     .font(.title3.weight(.semibold))
@@ -36,26 +68,28 @@ struct FileAccessSettingsTab: View {
 
             authorizedFoldersList
         }
-        .padding(20)
-        .padding(.bottom, 28)
-        .frame(maxWidth: 760, alignment: .topLeading)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
-            selectedGrantIDs.formIntersection(grantIDs)
-        }
-        .alert(
-            String(localized: "Couldn't Add Folder"),
-            isPresented: authorizationErrorBinding
-        ) {
-            Button(String(localized: "OK"), role: .cancel) {}
-        } message: {
-            Text(authorizationError ?? String(localized: "AudioMator couldn't save access to this folder."))
+    }
+
+    private var watchedFoldersSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Watched Folders"))
+                    .font(.title3.weight(.semibold))
+
+                Text(String(localized: "Watched folders stay in the sidebar across launches."))
+                    .foregroundStyle(.secondary)
+            }
+
+            watchedFoldersList
         }
     }
 
     private var authorizedFoldersList: some View {
         GroupBox {
             VStack(spacing: 0) {
+                Divider()
+                    .padding(.top, 8)
+
                 if viewModel.fileAccessGrants.isEmpty {
                     ContentUnavailableView(
                         String(localized: "No Authorized Folders"),
@@ -64,29 +98,69 @@ struct FileAccessSettingsTab: View {
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    List(selection: $selectedGrantIDs) {
+                    List(selection: $selectedFileAccessGrantIDs) {
                         ForEach(viewModel.fileAccessGrants) { grant in
-                            folderRow(grant)
+                            fileAccessFolderRow(grant)
                                 .tag(grant.id)
                         }
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
+                    .scrollIndicators(.visible, axes: .vertical)
+                    .scrollIndicatorsFlash(onAppear: true)
+                    .contentMargins(.top, 0, for: .scrollContent)
                     .padding(.horizontal, -8)
-                    .padding(.top, 4)
                 }
 
                 Divider()
 
-                folderActions
+                fileAccessFolderActions
                     .frame(height: 20)
             }
         }
-        .frame(height: authorizedFoldersListHeight)
-        .onDeleteCommand(perform: removeSelectedFolders)
+        .frame(height: folderListHeight)
+        .onDeleteCommand(perform: removeSelectedFileAccessFolders)
     }
 
-    private var authorizedFoldersListHeight: CGFloat {
+    private var watchedFoldersList: some View {
+        GroupBox {
+            VStack(spacing: 0) {
+                Divider()
+                    .padding(.top, 8)
+
+                if viewModel.watchedFolders.isEmpty {
+                    ContentUnavailableView(
+                        String(localized: "No watched folders yet"),
+                        systemImage: "folder",
+                        description: Text(String(localized: "Use the add button to watch a folder."))
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(selection: $selectedWatchedFolderIDs) {
+                        ForEach(viewModel.watchedFolders) { folder in
+                            watchedFolderRow(folder)
+                                .tag(folder.id)
+                        }
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .scrollIndicators(.visible, axes: .vertical)
+                    .scrollIndicatorsFlash(onAppear: true)
+                    .contentMargins(.top, 0, for: .scrollContent)
+                    .padding(.horizontal, -8)
+                }
+
+                Divider()
+
+                watchedFolderActions
+                    .frame(height: 20)
+            }
+        }
+        .frame(height: folderListHeight)
+        .onDeleteCommand(perform: removeSelectedWatchedFolders)
+    }
+
+    private var folderListHeight: CGFloat {
         280
     }
 
@@ -124,15 +198,49 @@ struct FileAccessSettingsTab: View {
         .frame(width: 360, alignment: .leading)
     }
 
-    private func folderRow(_ grant: FileAccessGrant) -> some View {
+    private func fileAccessFolderRow(_ grant: FileAccessGrant) -> some View {
+        folderRow(displayName: grant.displayName, url: grant.url)
+        .contextMenu {
+            Button(String(localized: "Remove"), role: .destructive) {
+                if selectedFileAccessGrantIDs.contains(grant.id) {
+                    removeSelectedFileAccessFolders()
+                } else {
+                    viewModel.removeFileAccessGrant(id: grant.id)
+                }
+            }
+        }
+    }
+
+    private func watchedFolderRow(_ folder: WatchedFolder) -> some View {
+        folderRow(
+            displayName: folder.displayName,
+            url: folder.url,
+            monitoringStatus: viewModel.directoryMonitoringStatuses[folder.id]
+        )
+        .contextMenu {
+            Button(String(localized: "Remove"), role: .destructive) {
+                if selectedWatchedFolderIDs.contains(folder.id) {
+                    removeSelectedWatchedFolders()
+                } else {
+                    viewModel.removeWatchedFolder(id: folder.id)
+                }
+            }
+        }
+    }
+
+    private func folderRow(
+        displayName: String,
+        url: URL,
+        monitoringStatus: DirectoryMonitoringStatus? = nil
+    ) -> some View {
         HStack(alignment: .center) {
             Image(systemName: "folder")
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(grant.displayName)
+                Text(displayName)
                     .lineLimit(1)
 
-                Text(grant.url.path(percentEncoded: false))
+                Text(url.path(percentEncoded: false))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -141,8 +249,16 @@ struct FileAccessSettingsTab: View {
 
             Spacer()
 
+            if let monitoringStatus, monitoringStatus.isDegraded {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .help(monitoringStatus.message)
+                    .accessibilityLabel(String(localized: "Folder monitoring degraded"))
+                    .accessibilityValue(monitoringStatus.message)
+            }
+
             Button {
-                PlatformWorkspace.open(grant.url)
+                PlatformWorkspace.open(url)
             } label: {
                 Label(String(localized: "Open Folder"), systemImage: "arrow.up.forward")
                     .labelStyle(.iconOnly)
@@ -150,22 +266,13 @@ struct FileAccessSettingsTab: View {
             .buttonStyle(.borderless)
             .help(String(localized: "Open Folder"))
         }
-        .contextMenu {
-            Button(String(localized: "Remove"), role: .destructive) {
-                if selectedGrantIDs.contains(grant.id) {
-                    removeSelectedFolders()
-                } else {
-                    viewModel.removeFileAccessGrant(id: grant.id)
-                }
-            }
-        }
-        .accessibilityLabel(grant.displayName)
-        .accessibilityValue(grant.url.path(percentEncoded: false))
+        .accessibilityLabel(displayName)
+        .accessibilityValue(url.path(percentEncoded: false))
     }
 
-    private var folderActions: some View {
+    private var fileAccessFolderActions: some View {
         HStack {
-            Button(action: addFolder) {
+            Button(action: addFileAccessFolder) {
                 Label(String(localized: "Add Folder"), systemImage: "plus")
                     .labelStyle(.iconOnly)
             }
@@ -175,12 +282,37 @@ struct FileAccessSettingsTab: View {
             Divider()
                 .frame(height: 16)
 
-            Button(action: removeSelectedFolders) {
+            Button(action: removeSelectedFileAccessFolders) {
                 Label(String(localized: "Remove Selected Folders"), systemImage: "minus")
                     .labelStyle(.iconOnly)
             }
             .buttonStyle(.borderless)
-            .disabled(selectedGrantIDs.isEmpty)
+            .disabled(selectedFileAccessGrantIDs.isEmpty)
+            .help(String(localized: "Remove Selected Folders"))
+
+            Spacer()
+        }
+        .controlSize(.small)
+    }
+
+    private var watchedFolderActions: some View {
+        HStack {
+            Button(action: addWatchedFolders) {
+                Label(String(localized: "Add Folder"), systemImage: "plus")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Add Watched Folder…"))
+
+            Divider()
+                .frame(height: 16)
+
+            Button(action: removeSelectedWatchedFolders) {
+                Label(String(localized: "Remove Selected Folders"), systemImage: "minus")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .disabled(selectedWatchedFolderIDs.isEmpty)
             .help(String(localized: "Remove Selected Folders"))
 
             Spacer()
@@ -199,10 +331,10 @@ struct FileAccessSettingsTab: View {
         )
     }
 
-    private func addFolder() {
+    private func addFileAccessFolder() {
         switch viewModel.authorizeDefaultFileAccessFolder() {
         case .authorized:
-            selectedGrantIDs.removeAll()
+            selectedFileAccessGrantIDs.removeAll()
         case .cancelled:
             break
         case .failure(let message):
@@ -210,10 +342,22 @@ struct FileAccessSettingsTab: View {
         }
     }
 
-    private func removeSelectedFolders() {
-        guard !selectedGrantIDs.isEmpty else { return }
-        viewModel.removeFileAccessGrants(ids: selectedGrantIDs)
-        selectedGrantIDs.removeAll()
+    private func addWatchedFolders() {
+        let existingIDs = Set(viewModel.watchedFolders.map(\.id))
+        _ = viewModel.addWatchedFolders()
+        selectedWatchedFolderIDs = Set(viewModel.watchedFolders.map(\.id)).subtracting(existingIDs)
+    }
+
+    private func removeSelectedFileAccessFolders() {
+        guard !selectedFileAccessGrantIDs.isEmpty else { return }
+        viewModel.removeFileAccessGrants(ids: selectedFileAccessGrantIDs)
+        selectedFileAccessGrantIDs.removeAll()
+    }
+
+    private func removeSelectedWatchedFolders() {
+        guard !selectedWatchedFolderIDs.isEmpty else { return }
+        viewModel.removeWatchedFolders(ids: selectedWatchedFolderIDs)
+        selectedWatchedFolderIDs.removeAll()
     }
 }
 #endif

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct FileAccessSettingsTab: View {
     @ObservedObject var viewModel: AudioViewModel
 
-    @State private var selectedGrantID: FileAccessGrant.ID?
+    @State private var selectedGrantIDs: Set<FileAccessGrant.ID> = []
     @State private var authorizationError: String?
     @State private var isFileAccessInfoPresented = false
 
@@ -41,8 +41,7 @@ struct FileAccessSettingsTab: View {
         .frame(maxWidth: 760, alignment: .topLeading)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
-            guard let selectedGrantID, !grantIDs.contains(selectedGrantID) else { return }
-            self.selectedGrantID = nil
+            selectedGrantIDs.formIntersection(grantIDs)
         }
         .alert(
             String(localized: "Couldn't Add Folder"),
@@ -65,7 +64,7 @@ struct FileAccessSettingsTab: View {
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    List(selection: $selectedGrantID) {
+                    List(selection: $selectedGrantIDs) {
                         ForEach(viewModel.fileAccessGrants) { grant in
                             folderRow(grant)
                                 .tag(grant.id)
@@ -84,7 +83,7 @@ struct FileAccessSettingsTab: View {
             }
         }
         .frame(height: authorizedFoldersListHeight)
-        .onDeleteCommand(perform: removeSelectedFolder)
+        .onDeleteCommand(perform: removeSelectedFolders)
     }
 
     private var authorizedFoldersListHeight: CGFloat {
@@ -153,8 +152,11 @@ struct FileAccessSettingsTab: View {
         }
         .contextMenu {
             Button(String(localized: "Remove"), role: .destructive) {
-                selectedGrantID = grant.id
-                removeSelectedFolder()
+                if selectedGrantIDs.contains(grant.id) {
+                    removeSelectedFolders()
+                } else {
+                    viewModel.removeFileAccessGrant(id: grant.id)
+                }
             }
         }
         .accessibilityLabel(grant.displayName)
@@ -173,13 +175,13 @@ struct FileAccessSettingsTab: View {
             Divider()
                 .frame(height: 16)
 
-            Button(action: removeSelectedFolder) {
-                Label(String(localized: "Remove Selected Folder"), systemImage: "minus")
+            Button(action: removeSelectedFolders) {
+                Label(String(localized: "Remove Selected Folders"), systemImage: "minus")
                     .labelStyle(.iconOnly)
             }
             .buttonStyle(.borderless)
-            .disabled(selectedGrantID == nil)
-            .help(String(localized: "Remove Selected Folder"))
+            .disabled(selectedGrantIDs.isEmpty)
+            .help(String(localized: "Remove Selected Folders"))
 
             Spacer()
         }
@@ -200,7 +202,7 @@ struct FileAccessSettingsTab: View {
     private func addFolder() {
         switch viewModel.authorizeDefaultFileAccessFolder() {
         case .authorized:
-            selectedGrantID = nil
+            selectedGrantIDs.removeAll()
         case .cancelled:
             break
         case .failure(let message):
@@ -208,10 +210,10 @@ struct FileAccessSettingsTab: View {
         }
     }
 
-    private func removeSelectedFolder() {
-        guard let selectedGrantID else { return }
-        viewModel.removeFileAccessGrant(id: selectedGrantID)
-        self.selectedGrantID = nil
+    private func removeSelectedFolders() {
+        guard !selectedGrantIDs.isEmpty else { return }
+        viewModel.removeFileAccessGrants(ids: selectedGrantIDs)
+        selectedGrantIDs.removeAll()
     }
 }
 #endif

--- a/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
+++ b/AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift
@@ -1,0 +1,183 @@
+#if os(macOS)
+import SwiftUI
+
+struct FileAccessSettingsTab: View {
+    @ObservedObject var viewModel: AudioViewModel
+
+    @State private var selectedGrantID: FileAccessGrant.ID?
+    @State private var authorizationError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(String(localized: "File Access"))
+                .font(.title3.weight(.semibold))
+
+            authorizedFoldersList
+        }
+        .padding(20)
+        .padding(.bottom, 8)
+        .frame(maxWidth: 760, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onChange(of: viewModel.fileAccessGrants.map(\.id)) { _, grantIDs in
+            guard let selectedGrantID, !grantIDs.contains(selectedGrantID) else { return }
+            self.selectedGrantID = nil
+        }
+        .alert(
+            String(localized: "Couldn't Add Folder"),
+            isPresented: authorizationErrorBinding
+        ) {
+            Button(String(localized: "OK"), role: .cancel) {}
+        } message: {
+            Text(authorizationError ?? String(localized: "AudioMator couldn't save access to this folder."))
+        }
+    }
+
+    private var authorizedFoldersList: some View {
+        GroupBox {
+            VStack(spacing: 0) {
+                List(selection: $selectedGrantID) {
+                    Text(
+                        String(
+                            localized: "Allow AudioMator to access the folders below between launches."
+                        )
+                    )
+                    .foregroundStyle(.secondary)
+                    .listRowInsets(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
+
+                    if viewModel.fileAccessGrants.isEmpty {
+                        ContentUnavailableView(
+                            String(localized: "No Authorized Folders"),
+                            systemImage: "folder",
+                            description: Text(String(localized: "Use the add button to grant access to a folder."))
+                        )
+                        .listRowInsets(EdgeInsets(top: 12, leading: 10, bottom: 12, trailing: 10))
+                    } else {
+                        ForEach(viewModel.fileAccessGrants) { grant in
+                            folderRow(grant)
+                                .tag(grant.id)
+                                .listRowInsets(EdgeInsets(top: 3, leading: 10, bottom: 3, trailing: 10))
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .contentMargins(.horizontal, 0, for: .scrollContent)
+                .contentMargins(.vertical, 0, for: .scrollContent)
+
+                Divider()
+
+                folderActions
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: authorizedFoldersListHeight)
+        .onDeleteCommand(perform: removeSelectedFolder)
+    }
+
+    private var authorizedFoldersListHeight: CGFloat {
+        let descriptionHeight: CGFloat = 36
+        let toolbarHeight: CGFloat = 29
+        let groupInsets: CGFloat = 18
+        let contentHeight: CGFloat
+
+        if viewModel.fileAccessGrants.isEmpty {
+            contentHeight = 120
+        } else {
+            contentHeight = min(CGFloat(viewModel.fileAccessGrants.count) * 40, 280)
+        }
+
+        return descriptionHeight + contentHeight + toolbarHeight + groupInsets
+    }
+
+    private func folderRow(_ grant: FileAccessGrant) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(grant.displayName)
+                    .lineLimit(1)
+
+                Text(grant.url.path(percentEncoded: false))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        } icon: {
+            Image(systemName: "folder")
+        }
+        .contextMenu {
+            Button(String(localized: "Remove"), role: .destructive) {
+                selectedGrantID = grant.id
+                removeSelectedFolder()
+            }
+        }
+        .accessibilityLabel(grant.displayName)
+        .accessibilityValue(grant.url.path(percentEncoded: false))
+    }
+
+    private var folderActions: some View {
+        HStack(spacing: 0) {
+            folderActionButton(
+                systemImage: "plus",
+                accessibilityLabel: String(localized: "Add Folder"),
+                action: addFolder
+            )
+
+            Divider()
+                .frame(height: 16)
+
+            folderActionButton(
+                systemImage: "minus",
+                accessibilityLabel: String(localized: "Remove Selected Folder"),
+                action: removeSelectedFolder
+            )
+            .disabled(selectedGrantID == nil)
+
+            Spacer()
+        }
+        .padding(.leading, 4)
+        .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+    }
+
+    private func folderActionButton(
+        systemImage: String,
+        accessibilityLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.borderless)
+        .accessibilityLabel(accessibilityLabel)
+        .help(accessibilityLabel)
+    }
+
+    private var authorizationErrorBinding: Binding<Bool> {
+        Binding(
+            get: { authorizationError != nil },
+            set: { isPresented in
+                if !isPresented {
+                    authorizationError = nil
+                }
+            }
+        )
+    }
+
+    private func addFolder() {
+        switch viewModel.authorizeDefaultFileAccessFolder() {
+        case .authorized:
+            selectedGrantID = nil
+        case .cancelled:
+            break
+        case .failure(let message):
+            authorizationError = message
+        }
+    }
+
+    private func removeSelectedFolder() {
+        guard let selectedGrantID else { return }
+        viewModel.removeFileAccessGrant(id: selectedGrantID)
+        self.selectedGrantID = nil
+    }
+}
+#endif

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -709,7 +709,19 @@ private struct SaveIssueLogSettingsTab: View {
                         .foregroundStyle(.secondary)
                 }
 
-                MacSettingsSection(title: "Recent Save Issues") {
+                HStack(spacing: 12) {
+                    Button("Copy All") {
+                        copyEntriesToPasteboard()
+                    }
+                    .disabled(store.entries.isEmpty)
+
+                    Button("Clear Logs", role: .destructive) {
+                        store.clear()
+                    }
+                    .disabled(store.entries.isEmpty)
+                }
+
+                MacSettingsSection(title: nil) {
                     if store.entries.isEmpty {
                         emptyState
                     } else {
@@ -723,22 +735,6 @@ private struct SaveIssueLogSettingsTab: View {
                             }
                         }
                     }
-                }
-
-                HStack(alignment: .firstTextBaseline, spacing: 12) {
-                    Button("Copy All") {
-                        copyEntriesToPasteboard()
-                    }
-                    .disabled(store.entries.isEmpty)
-
-                    Button("Clear Logs", role: .destructive) {
-                        store.clear()
-                    }
-                    .disabled(store.entries.isEmpty)
-
-                    Text("\(store.entries.count) saved issue\(store.entries.count == 1 ? "" : "s").")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
                 }
             }
             .padding(20)

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -50,14 +50,6 @@ struct SettingsView: View {
             }
             .tag(AppSettingsTab.general)
 
-            #if os(macOS)
-            FileAccessSettingsTab(viewModel: viewModel)
-                .tabItem {
-                    Label("Folders", systemImage: "folder")
-                }
-                .tag(AppSettingsTab.fileAccess)
-            #endif
-
             InterfaceSettingsTab(
                 sharedState: sharedState,
                 toolbarButtonVisibilityBinding: toolbarButtonVisibilityBinding(for:),
@@ -70,6 +62,14 @@ struct SettingsView: View {
                 Label("Interface", systemImage: "macwindow")
             }
             .tag(AppSettingsTab.interface)
+
+            #if os(macOS)
+            FileAccessSettingsTab(viewModel: viewModel)
+                .tabItem {
+                    Label("Folders", systemImage: "folder")
+                }
+                .tag(AppSettingsTab.fileAccess)
+            #endif
 
             SaveIssueLogSettingsTab(store: saveIssueLogStore)
                 .tabItem {

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -462,7 +462,15 @@ private struct GeneralSettingsTab: View {
                         MacSettingsRow(
                             title: "MuseAmp Compatibility",
                             detail: "Enable MuseAmp ID actions in track list context menus.",
-                            systemImage: "music.note.list"
+                            systemImage: "music.note.list",
+                            info: MacSettingsInfo(
+                                title: String(localized: "About MuseAmp Compatibility"),
+                                message: String(localized: "MuseAmp ID generation is provided for compatibility with MuseAmp."),
+                                linkTitle: String(localized: "View MuseAmp on GitHub"),
+                                linkURL: URL(string: "https://github.com/Lakr233/MuseAmp"),
+                                disclaimer: String(localized: "AudioMator is an independent project and is not affiliated with, endorsed by, sponsored by, or otherwise associated with MuseAmp or its developers."),
+                                credit: String(localized: "Full credit for the original application, architecture, and core design belongs to the upstream project and its original contributors.")
+                            )
                         ) {
                             Toggle("MuseAmp Compatibility", isOn: $isMuseAmpSupportEnabled)
                                 .labelsHidden()
@@ -507,21 +515,34 @@ private struct MacSettingsSection<Content: View>: View {
     }
 }
 
+private struct MacSettingsInfo {
+    let title: String
+    let message: String
+    let linkTitle: String?
+    let linkURL: URL?
+    let disclaimer: String?
+    let credit: String?
+}
+
 private struct MacSettingsRow<Accessory: View>: View {
     let title: String
     let detail: String?
     let systemImage: String
+    let info: MacSettingsInfo?
     @ViewBuilder let accessory: Accessory
+    @State private var isInfoPresented: Bool = false
 
     init(
         title: String,
         detail: String? = nil,
         systemImage: String,
+        info: MacSettingsInfo? = nil,
         @ViewBuilder accessory: () -> Accessory
     ) {
         self.title = title
         self.detail = detail
         self.systemImage = systemImage
+        self.info = info
         self.accessory = accessory()
     }
 
@@ -533,10 +554,62 @@ private struct MacSettingsRow<Accessory: View>: View {
                 .frame(width: 26, height: 26)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(.body)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.85)
+                HStack(spacing: 5) {
+                    Text(title)
+                        .font(.body)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.85)
+
+                    if let info {
+                        Button {
+                            isInfoPresented.toggle()
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 18, height: 18)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .help(info.title)
+                        .accessibilityLabel(info.title)
+                        .popover(isPresented: $isInfoPresented, arrowEdge: .bottom) {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Label(info.title, systemImage: "info.circle.fill")
+                                    .font(.headline)
+
+                                Text(info.message)
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+
+                                if let linkTitle = info.linkTitle, let linkURL = info.linkURL {
+                                    Link(linkTitle, destination: linkURL)
+                                        .font(.callout)
+                                }
+
+                                if info.disclaimer != nil || info.credit != nil {
+                                    Divider()
+                                }
+
+                                if let disclaimer = info.disclaimer {
+                                    Text(disclaimer)
+                                        .font(.callout)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+
+                                if let credit = info.credit {
+                                    Text(credit)
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                            .padding(16)
+                            .frame(width: 320, alignment: .leading)
+                        }
+                    }
+                }
 
                 if let detail {
                     Text(detail)

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -7,6 +7,9 @@ let settingsSelectedTabDefaultsKey = "settings.selectedTab"
 
 enum AppSettingsTab: String, Hashable {
     case general
+    #if os(macOS)
+    case fileAccess
+    #endif
     case toolbar
     case columns
     case inspector
@@ -26,6 +29,7 @@ private func formattedAboutDescription(copyright: String) -> String {
 }
 
 struct SettingsView: View {
+    @ObservedObject var viewModel: AudioViewModel
     @ObservedObject var sharedState: SharedState
     @ObservedObject var saveIssueLogStore: SaveIssueLogStore
 
@@ -47,6 +51,14 @@ struct SettingsView: View {
                 Label("General", systemImage: "gearshape")
             }
             .tag(AppSettingsTab.general)
+
+            #if os(macOS)
+            FileAccessSettingsTab(viewModel: viewModel)
+                .tabItem {
+                    Label("File Access", systemImage: "folder")
+                }
+                .tag(AppSettingsTab.fileAccess)
+            #endif
 
             ToolbarSettingsTab(
                 sharedState: sharedState,
@@ -1630,6 +1642,10 @@ private struct ReleaseMarkdownText: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView(sharedState: SharedState(), saveIssueLogStore: SaveIssueLogStore())
+        SettingsView(
+            viewModel: AudioViewModel(),
+            sharedState: SharedState(),
+            saveIssueLogStore: SaveIssueLogStore()
+        )
     }
 }

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -10,9 +10,7 @@ enum AppSettingsTab: String, Hashable {
     #if os(macOS)
     case fileAccess
     #endif
-    case toolbar
-    case columns
-    case inspector
+    case interface
     case logs
     case about
 }
@@ -60,34 +58,18 @@ struct SettingsView: View {
                 .tag(AppSettingsTab.fileAccess)
             #endif
 
-            ToolbarSettingsTab(
+            InterfaceSettingsTab(
                 sharedState: sharedState,
-                toolbarButtonVisibilityBinding: toolbarButtonVisibilityBinding(for:)
-            )
-            .tabItem {
-                Label("Toolbar", systemImage: "switch.2")
-            }
-            .tag(AppSettingsTab.toolbar)
-
-            ColumnVisibilitySettingsTab(
-                sharedState: sharedState,
+                toolbarButtonVisibilityBinding: toolbarButtonVisibilityBinding(for:),
                 columnVisibilityBinding: columnVisibilityBinding(for:),
-                isLastVisibleColumn: isLastVisibleColumn
-            )
-            .tabItem {
-                Label("Columns", systemImage: "rectangle.split.3x1")
-            }
-            .tag(AppSettingsTab.columns)
-
-            InspectorSettingsTab(
-                sharedState: sharedState,
+                isLastVisibleColumn: isLastVisibleColumn,
                 metadataFieldVisibilityBinding: metadataFieldVisibilityBinding(for:),
                 isLastVisibleMetadataField: isLastVisibleMetadataField
             )
             .tabItem {
-                Label("Inspector", systemImage: "sidebar.right")
+                Label("Interface", systemImage: "macwindow")
             }
-            .tag(AppSettingsTab.inspector)
+            .tag(AppSettingsTab.interface)
 
             SaveIssueLogSettingsTab(store: saveIssueLogStore)
                 .tabItem {
@@ -111,7 +93,14 @@ struct SettingsView: View {
 
     private var selectedTabBinding: Binding<AppSettingsTab> {
         Binding(
-            get: { AppSettingsTab(rawValue: selectedTabRawValue) ?? .general },
+            get: {
+                switch selectedTabRawValue {
+                case "toolbar", "columns", "inspector":
+                    return .interface
+                default:
+                    return AppSettingsTab(rawValue: selectedTabRawValue) ?? .general
+                }
+            },
             set: { selectedTabRawValue = $0.rawValue }
         )
     }
@@ -577,91 +566,31 @@ private struct MacSettingsDivider: View {
     }
 }
 
-private struct ColumnVisibilitySettingsTab: View {
+private struct InterfaceSettingsTab: View {
     @ObservedObject var sharedState: SharedState
+    let toolbarButtonVisibilityBinding: (ToolbarButtonOption) -> Binding<Bool>
     let columnVisibilityBinding: (MiddleListColumn) -> Binding<Bool>
     let isLastVisibleColumn: (MiddleListColumn) -> Bool
+    let metadataFieldVisibilityBinding: (InspectorMetadataField) -> Binding<Bool>
+    let isLastVisibleMetadataField: (InspectorMetadataField) -> Bool
 
-    private let columnGridColumns: [GridItem] = [
+    private let optionGridColumns: [GridItem] = [
         GridItem(.flexible(minimum: 220), alignment: .leading),
         GridItem(.flexible(minimum: 220), alignment: .leading)
     ]
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Middle List Columns")
-                        .font(.title3.weight(.semibold))
-
-                    Text("Choose which columns appear in the main track list.")
-                        .foregroundStyle(.secondary)
-                }
-
-                LazyVGrid(columns: columnGridColumns, alignment: .leading, spacing: 12) {
-                    ForEach(MiddleListColumn.allCases) { column in
-                        Toggle(column.displayName, isOn: columnVisibilityBinding(column))
-                            .disabled(isLastVisibleColumn(column))
-                    }
-                }
-                Divider()
-
-                HStack(alignment: .firstTextBaseline, spacing: 16) {
-                    Button("Restore Default Columns") {
-                        sharedState.visibleMiddleListColumns = Set(MiddleListColumn.defaultVisibleColumns)
-                    }
-                }
-            }
-            .padding(20)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
-        }
-        .audiomatorScrollEdgeEffect(.soft, for: .vertical)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-}
-
-private struct ToolbarSettingsTab: View {
-    @ObservedObject var sharedState: SharedState
-    let toolbarButtonVisibilityBinding: (ToolbarButtonOption) -> Binding<Bool>
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Toolbar Buttons")
-                        .font(.title3.weight(.semibold))
-
-                    Text("Choose which actions appear in the main window toolbar.")
-                        .foregroundStyle(.secondary)
-                }
-
-                MacSettingsSection(title: nil) {
-                    ForEach(ToolbarButtonOption.allCases) { button in
-                        MacSettingsRow(
-                            title: button.displayName,
-                            detail: button.settingsDescription,
-                            systemImage: button.systemImage
-                        ) {
-                            Toggle(button.displayName, isOn: toolbarButtonVisibilityBinding(button))
-                                .labelsHidden()
-                                .toggleStyle(.switch)
-                                .controlSize(.small)
-                                .accessibilityLabel(button.displayName)
-                        }
-
-                        if button != ToolbarButtonOption.allCases.last {
-                            MacSettingsDivider()
-                        }
-                    }
-                }
+            VStack(alignment: .leading, spacing: 24) {
+                toolbarSection
 
                 Divider()
 
-                HStack(alignment: .firstTextBaseline, spacing: 16) {
-                    Button("Restore Default Buttons") {
-                        sharedState.visibleToolbarButtons = Set(ToolbarButtonOption.defaultVisibleButtons)
-                    }
-                }
+                columnsSection
+
+                Divider()
+
+                inspectorSection
             }
             .padding(20)
             .padding(.bottom, 28)
@@ -671,48 +600,91 @@ private struct ToolbarSettingsTab: View {
         .audiomatorScrollEdgeEffect(.soft, for: .vertical)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
-}
 
-private struct InspectorSettingsTab: View {
-    @ObservedObject var sharedState: SharedState
-    let metadataFieldVisibilityBinding: (InspectorMetadataField) -> Binding<Bool>
-    let isLastVisibleMetadataField: (InspectorMetadataField) -> Bool
+    private var toolbarSection: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            settingsSectionHeader(
+                title: "Toolbar Buttons",
+                detail: "Choose which actions appear in the main window toolbar."
+            )
 
-    private let fieldGridColumns: [GridItem] = [
-        GridItem(.flexible(minimum: 220), alignment: .leading),
-        GridItem(.flexible(minimum: 220), alignment: .leading)
-    ]
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Inspector Metadata Fields")
-                        .font(.title3.weight(.semibold))
-
-                    Text("Choose which metadata fields appear in the right inspector.")
-                        .foregroundStyle(.secondary)
-                }
-
-                LazyVGrid(columns: fieldGridColumns, alignment: .leading, spacing: 12) {
-                    ForEach(InspectorMetadataField.allCases) { field in
-                        Toggle(field.displayName, isOn: metadataFieldVisibilityBinding(field))
-                            .disabled(isLastVisibleMetadataField(field))
+            MacSettingsSection(title: nil) {
+                ForEach(ToolbarButtonOption.allCases) { button in
+                    MacSettingsRow(
+                        title: button.displayName,
+                        detail: button.settingsDescription,
+                        systemImage: button.systemImage
+                    ) {
+                        Toggle(button.displayName, isOn: toolbarButtonVisibilityBinding(button))
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                            .accessibilityLabel(button.displayName)
                     }
-                }
-                Divider()
 
-                HStack(alignment: .firstTextBaseline, spacing: 16) {
-                    Button("Restore Default Metadata Fields") {
-                        sharedState.visibleInspectorMetadataFields = Set(InspectorMetadataField.defaultVisibleFields)
+                    if button != ToolbarButtonOption.allCases.last {
+                        MacSettingsDivider()
                     }
                 }
             }
-            .padding(20)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+
+            Button("Restore Toolbar") {
+                sharedState.visibleToolbarButtons = Set(ToolbarButtonOption.defaultVisibleButtons)
+            }
         }
-        .audiomatorScrollEdgeEffect(.soft, for: .vertical)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var columnsSection: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            settingsSectionHeader(
+                title: "Middle List Columns",
+                detail: "Choose which columns appear in the main track list."
+            )
+
+            LazyVGrid(columns: optionGridColumns, alignment: .leading, spacing: 12) {
+                ForEach(MiddleListColumn.allCases) { column in
+                    Toggle(column.displayName, isOn: columnVisibilityBinding(column))
+                        .disabled(isLastVisibleColumn(column))
+                }
+            }
+
+            Button("Restore List Columns") {
+                sharedState.visibleMiddleListColumns = Set(MiddleListColumn.defaultVisibleColumns)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var inspectorSection: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            settingsSectionHeader(
+                title: "Inspector Metadata Fields",
+                detail: "Choose which metadata fields appear in the right inspector."
+            )
+
+            LazyVGrid(columns: optionGridColumns, alignment: .leading, spacing: 12) {
+                ForEach(InspectorMetadataField.allCases) { field in
+                    Toggle(field.displayName, isOn: metadataFieldVisibilityBinding(field))
+                        .disabled(isLastVisibleMetadataField(field))
+                }
+            }
+
+            Button("Restore Inspector Metadata Fields") {
+                sharedState.visibleInspectorMetadataFields = Set(InspectorMetadataField.defaultVisibleFields)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func settingsSectionHeader(title: LocalizedStringKey, detail: LocalizedStringKey) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+
+            Text(detail)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/AudioMator/Features/Settings/Views/SettingsView.swift
+++ b/AudioMator/Features/Settings/Views/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingsView: View {
             #if os(macOS)
             FileAccessSettingsTab(viewModel: viewModel)
                 .tabItem {
-                    Label("File Access", systemImage: "folder")
+                    Label("Folders", systemImage: "folder")
                 }
                 .tag(AppSettingsTab.fileAccess)
             #endif

--- a/AudioMator/Features/iTunesBrowser/Views/iTunesTaggingWorkbenchView.swift
+++ b/AudioMator/Features/iTunesBrowser/Views/iTunesTaggingWorkbenchView.swift
@@ -629,13 +629,13 @@ private enum iTunesWorkbenchAppKitFactory {
         return label("iTunes: \(track.trackNumber > 0 ? "\(track.trackNumber) " : "")\(track.trackName)", font: .systemFont(ofSize: 11), color: .secondaryLabelColor)
     }
 
-    private static func trackOptionTitle(_ track: iTunesTrackResult) -> String {
+    nonisolated private static func trackOptionTitle(_ track: iTunesTrackResult) -> String {
         let number = track.trackNumber > 0 ? "\(track.trackNumber) " : ""
         let discPrefix = track.discCount > 1 ? "Disc \(track.discNumber) • " : ""
         return discPrefix + number + track.trackName
     }
 
-    private static func trackDetailLine(for track: iTunesTrackResult) -> String {
+    nonisolated private static func trackDetailLine(for track: iTunesTrackResult) -> String {
         [track.artistName, track.primaryGenreName, track.releaseDate].filter { !$0.isEmpty }.joined(separator: " • ")
     }
 

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -8974,6 +8974,9 @@
         }
       }
     },
+    "Open Folder" : {
+
+    },
     "Open MusicBrainz Browser" : {
       "comment" : "Button or menu command; translate as an action, usually concise. Context: MusicBrainz lookup, matching, or tag-writing workflow. Usage may be indirect through localized keys or generated SwiftUI extraction.",
       "extractionState" : "stale",

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -585,6 +585,47 @@
     "About Folder Access" : {
 
     },
+    "About MuseAmp Compatibility" : {
+      "comment" : "Title for the popup explaining how AudioMator works with MuseAmp.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About MuseAmp Compatibility"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About MuseAmp Compatibility"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于 MuseAmp 兼容性"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於 MuseAmp 相容性"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於 MuseAmp 相容性"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於 MuseAmp 相容性"
+          }
+        }
+      }
+    },
     "Acknowledgements" : {
       "comment" : "Screen, sheet, section, or navigation title. Used around: AudioMator/Features/Settings/Views/SettingsView.swift:18.",
       "localizations" : {
@@ -1551,6 +1592,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AudioMator"
+          }
+        }
+      }
+    },
+    "AudioMator is an independent project and is not affiliated with, endorsed by, sponsored by, or otherwise associated with MuseAmp or its developers." : {
+      "comment" : "Disclaimer clarifying that AudioMator is independent from MuseAmp and its developers.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AudioMator is an independent project and is not affiliated with, endorsed by, sponsored by, or otherwise associated with MuseAmp or its developers."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AudioMator is an independent project and is not affiliated with, endorsed by, sponsored by, or otherwise associated with MuseAmp or its developers."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AudioMator 是一个独立项目，与 MuseAmp 或其开发者没有隶属、认可、赞助或其他关联关系。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AudioMator 是獨立專案，與 MuseAmp 或其開發者不存在隸屬、認可、贊助或其他關聯。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AudioMator 是獨立專案，與 MuseAmp 或其開發者不存在隸屬、認可、贊助或其他關聯。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AudioMator 是獨立專案，與 MuseAmp 或其開發者不存在隸屬、認可、贊助或其他關聯。"
           }
         }
       }
@@ -7493,6 +7575,129 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "多檔案在線封面查找需要共享的 iTunes 專輯 ID 或專輯值。"
+          }
+        }
+      }
+    },
+    "Full credit for the original application, architecture, and core design belongs to the upstream project and its original contributors." : {
+      "comment" : "Credits MuseAmp's upstream project and original contributors.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full credit for the original application, architecture, and core design belongs to the upstream project and its original contributors."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full credit for the original application, architecture, and core design belongs to the upstream project and its original contributors."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始应用、架构和核心设计的全部荣誉归于上游项目及其原始贡献者。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始應用程式、架構及核心設計的全部榮譽歸於上游專案及其原始貢獻者。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始應用程式、架構及核心設計的全部榮譽歸於上游專案及其原始貢獻者。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始應用程式、架構及核心設計的全部榮譽歸於上游專案及其原始貢獻者。"
+          }
+        }
+      }
+    },
+    "MuseAmp ID generation is provided for compatibility with MuseAmp." : {
+      "comment" : "Explains why AudioMator provides MuseAmp ID generation.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MuseAmp ID generation is provided for compatibility with MuseAmp."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MuseAmp ID generation is provided for compatibility with MuseAmp."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MuseAmp ID 生成功能用于兼容 MuseAmp。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提供 MuseAmp ID 生成功能是為了相容 MuseAmp。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提供 MuseAmp ID 生成功能是為了相容 MuseAmp。"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提供 MuseAmp ID 生成功能是為了相容 MuseAmp。"
+          }
+        }
+      }
+    },
+    "View MuseAmp on GitHub" : {
+      "comment" : "Link title opening the MuseAmp repository on GitHub.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View MuseAmp on GitHub"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View MuseAmp on GitHub"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上查看 MuseAmp"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上檢視 MuseAmp"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上檢視 MuseAmp"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上檢視 MuseAmp"
           }
         }
       }

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -891,6 +891,9 @@
         }
       }
     },
+    "Add Folder" : {
+
+    },
     "Add Folder…" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1192,6 +1195,9 @@
       }
     },
     "Allow" : {
+
+    },
+    "Allow AudioMator to access the folders below between launches." : {
 
     },
     "Allow File Access" : {
@@ -1610,6 +1616,9 @@
 
     },
     "AudioMator couldn't save access to %lld selected folders." : {
+
+    },
+    "AudioMator couldn't save access to this folder." : {
 
     },
     "AudioMator keeps each file's current extension. The template changes only the filename." : {
@@ -3383,6 +3392,9 @@
         }
       }
     },
+    "Couldn't Add Folder" : {
+
+    },
     "Create IDs" : {
 
     },
@@ -4931,6 +4943,9 @@
           }
         }
       }
+    },
+    "File Access" : {
+
     },
     "File Exists" : {
       "comment" : "Status, validation, or empty-state message shown in the app UI. Used around: AudioMator/Domain/Rename/FileRenameTemplate.swift:120.",
@@ -8056,6 +8071,9 @@
         }
       }
     },
+    "No Authorized Folders" : {
+
+    },
     "No Candidate Selected" : {
 
     },
@@ -10467,7 +10485,13 @@
         }
       }
     },
+    "Remove" : {
+
+    },
     "Remove Folder" : {
+
+    },
+    "Remove Selected Folder" : {
 
     },
     "Remove watched folder" : {
@@ -13945,6 +13969,9 @@
 
     },
     "Use Selected Artwork" : {
+
+    },
+    "Use the add button to grant access to a folder." : {
 
     },
     "Utilities…" : {

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -5321,6 +5321,9 @@
     "Folder Not Added" : {
 
     },
+    "Folders" : {
+
+    },
     "Format" : {
       "comment" : "Audio metadata field label; prefer the term users expect in music tag editors. Used around: AudioMator/Domain/UIState/MiddleListColumn.swift:71, AudioMator/Domain/AudioFiles/AudioFile.swift:556, AudioMator/Infrastructure/MusicBrainz/MusicBrainzClient.swift:232, AudioMator/Features/Main/ViewModels/AudioViewModel+MetadataWrite.swift:3.",
       "localizations" : {
@@ -13987,6 +13990,9 @@
 
     },
     "Use the add button to grant access to a folder." : {
+
+    },
+    "Use the add button to watch a folder." : {
 
     },
     "Utilities…" : {

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -5678,6 +5678,7 @@
     },
     "Inspector" : {
       "comment" : "Screen, sheet, section, or navigation title. Used around: AudioMator/App/AppNotifications.swift:10, AudioMator/Domain/UIState/SharedState.swift:12, AudioMator/Domain/UIState/InspectorMetadataField.swift:3, AudioMator/Domain/UIState/ToolbarButtonOption.swift:5.",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -5763,6 +5764,47 @@
     },
     "Instrumental Result" : {
 
+    },
+    "Interface" : {
+      "comment" : "Settings tab containing toolbar, track-list column, and inspector visibility options.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "界面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面"
+          }
+        },
+        "zh-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面"
+          }
+        }
+      }
     },
     "ISRC" : {
       "comment" : "Audio metadata field label; prefer the term users expect in music tag editors. Used around: AudioMator/Domain/UIState/MiddleListColumn.swift:343, AudioMator/Infrastructure/MusicBrainz/MusicBrainzClient.swift:3191, AudioMator/Features/MusicBrainzBrowser/ViewModels/MusicBrainzTaggingWorkbenchStore.swift:64, AudioMator/Features/MusicBrainzBrowser/ViewModels/MusicBrainzBrowserStore.swift:85.",
@@ -10943,12 +10985,6 @@
     "Reset" : {
 
     },
-    "Restore Default Buttons" : {
-
-    },
-    "Restore Default Columns" : {
-
-    },
     "Restore Default Metadata Fields" : {
       "comment" : "Button or menu command; translate as an action, usually concise. Context: audio metadata/tag editing workflow. Used around: AudioMator/Features/Settings/Views/SettingsView.swift:298.",
       "localizations" : {
@@ -10989,6 +11025,15 @@
           }
         }
       }
+    },
+    "Restore Inspector Metadata Fields" : {
+
+    },
+    "Restore List Columns" : {
+
+    },
+    "Restore Toolbar" : {
+
     },
     "Results" : {
 
@@ -11839,10 +11884,10 @@
     "Select one or more files to preview text export." : {
 
     },
-    "Select the exact folder “%@” to continue." : {
+    "Select one or more folders containing the audio files you edit, such as your user folder." : {
 
     },
-    "Select one or more folders containing the audio files you edit, such as your user folder." : {
+    "Select the exact folder “%@” to continue." : {
 
     },
     "Selected Fields" : {
@@ -13225,9 +13270,6 @@
           }
         }
       }
-    },
-    "Toolbar" : {
-
     },
     "Toolbar Buttons" : {
       "comment" : "Screen, sheet, section, or navigation title. Used around: AudioMator/Features/Settings/Views/SettingsView.swift:613.",

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -421,16 +421,6 @@
         }
       }
     },
-    "%lld saved issue%@." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld saved issue%2$@."
-          }
-        }
-      }
-    },
     "%lld%%" : {
 
     },

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -10503,7 +10503,7 @@
     "Remove Folder" : {
 
     },
-    "Remove Selected Folder" : {
+    "Remove Selected Folders" : {
 
     },
     "Remove watched folder" : {
@@ -11839,7 +11839,7 @@
     "Select the exact folder “%@” to continue." : {
 
     },
-    "Select your user folder, or another folder containing the audio files you edit." : {
+    "Select one or more folders containing the audio files you edit, such as your user folder." : {
 
     },
     "Selected Fields" : {

--- a/AudioMator/Localizable.xcstrings
+++ b/AudioMator/Localizable.xcstrings
@@ -582,6 +582,9 @@
         }
       }
     },
+    "About Folder Access" : {
+
+    },
     "Acknowledgements" : {
       "comment" : "Screen, sheet, section, or navigation title. Used around: AudioMator/Features/Settings/Views/SettingsView.swift:18.",
       "localizations" : {
@@ -1197,9 +1200,6 @@
     "Allow" : {
 
     },
-    "Allow AudioMator to access the folders below between launches." : {
-
-    },
     "Allow File Access" : {
 
     },
@@ -1702,6 +1702,9 @@
           }
         }
       }
+    },
+    "AudioMator runs in the macOS App Sandbox. It can read and edit files only in folders you choose." : {
+
     },
     "AudioMator uses transactional saves to reduce the chance that a failed operation leaves an audio file partially written." : {
 
@@ -2696,6 +2699,9 @@
           }
         }
       }
+    },
+    "Choose which folders AudioMator can access between launches." : {
+
     },
     "Choose which metadata fields appear in the right inspector." : {
       "comment" : "Explanatory helper text, warning, or validation copy. Context: audio metadata/tag editing workflow. Used around: AudioMator/Features/Settings/Views/SettingsView.swift:663.",
@@ -5528,6 +5534,9 @@
           }
         }
       }
+    },
+    "If a folder is moved or renamed, macOS may require you to authorize it again." : {
+
     },
     "If that's unexpected, make sure the file is an MP3 and TagLib can read it." : {
       "comment" : "Explanatory helper text, warning, or validation copy. Used around: AudioMator/Features/MetadataInspector/Views/MetadataInspectorSheet.swift:88.",
@@ -10581,6 +10590,9 @@
           }
         }
       }
+    },
+    "Removing a folder from this list removes AudioMator's saved access. It does not delete or modify the folder or any files inside it." : {
+
     },
     "Rename" : {
       "comment" : "Button or menu command; translate as an action, usually concise. Used around: AudioMator/App/AppNotifications.swift:7, AudioMator/Domain/MetadataExchange/MetadataExchange.swift:67, AudioMator/Domain/Rename/FileRenameTemplate.swift:4, AudioMator/Domain/Rename/FilenameMetadataTemplate.swift:4.",

--- a/AudioMatorTests/DirectoryMonitoringPlanTests.swift
+++ b/AudioMatorTests/DirectoryMonitoringPlanTests.swift
@@ -88,6 +88,49 @@ final class DirectoryMonitoringPlanTests: XCTestCase {
         XCTAssertEqual(Set(persistedRecords.map(\.id)), Set([unresolvedID, validFolder.id]))
     }
 
+    @MainActor
+    func testViewModelRemovesMultipleWatchedFoldersTogether() throws {
+        let suiteName = "AudioMator.WatchedFolderMultipleRemovalTests.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let folderURLs = (0..<3).map { index in
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("AudioMator-WatchedFolder-\(index)-\(UUID().uuidString)", isDirectory: true)
+        }
+        for folderURL in folderURLs {
+            try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        }
+        defer {
+            for folderURL in folderURLs {
+                try? FileManager.default.removeItem(at: folderURL)
+            }
+        }
+
+        let watchedFolderStore = WatchedFolderStore(userDefaults: userDefaults)
+        let folders = try folderURLs.map(watchedFolderStore.makeFolder)
+        watchedFolderStore.saveFolders(folders)
+        let viewModel = AudioViewModel(
+            watchedFolderStore: watchedFolderStore,
+            fileAccessGrantStore: FileAccessGrantStore(userDefaults: userDefaults),
+            metadataPipeline: TagLibAudioMetadataPipeline(),
+            saveIssueLogStore: SaveIssueLogStore()
+        )
+        defer {
+            viewModel.removeWatchedFolders(ids: Set(viewModel.watchedFolders.map(\.id)))
+        }
+
+        viewModel.removeWatchedFolders(ids: [folders[0].id, folders[2].id])
+
+        XCTAssertEqual(viewModel.watchedFolders.map(\.id), [folders[1].id])
+        XCTAssertEqual(
+            WatchedFolderStore(userDefaults: userDefaults).loadFolders().map(\.id),
+            [folders[1].id]
+        )
+    }
+
     func testPlanIsBoundedAndAlwaysPrioritizesRootDirectory() {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("AudioMatorMonitorRoot", isDirectory: true)

--- a/AudioMatorTests/FileAccessGrantStoreTests.swift
+++ b/AudioMatorTests/FileAccessGrantStoreTests.swift
@@ -55,4 +55,72 @@ final class FileAccessGrantStoreTests: XCTestCase {
         let restoredGrants = FileAccessGrantStore(userDefaults: defaults).loadGrants()
         XCTAssertEqual(restoredGrants.map(\.id), [secondGrant.id])
     }
+
+    func testViewModelRemovalUpdatesPublishedAndPersistedGrants() throws {
+        let suiteName = "FileAccessGrantStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults.")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let firstFolderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioMatorFileAccessGrant-\(UUID().uuidString)", isDirectory: true)
+        let secondFolderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioMatorFileAccessGrant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstFolderURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondFolderURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: firstFolderURL)
+            try? FileManager.default.removeItem(at: secondFolderURL)
+        }
+
+        let fileAccessGrantStore = FileAccessGrantStore(userDefaults: defaults)
+        let firstGrant = try fileAccessGrantStore.makeGrant(from: firstFolderURL)
+        let secondGrant = try fileAccessGrantStore.makeGrant(from: secondFolderURL)
+        fileAccessGrantStore.saveGrants([firstGrant, secondGrant])
+        let viewModel = makeViewModel(defaults: defaults)
+
+        viewModel.removeFileAccessGrant(id: firstGrant.id)
+
+        XCTAssertEqual(viewModel.fileAccessGrants.map(\.id), [secondGrant.id])
+        XCTAssertEqual(
+            FileAccessGrantStore(userDefaults: defaults).loadGrants().map(\.id),
+            [secondGrant.id]
+        )
+    }
+
+    func testViewModelIgnoresRemovalOfUnknownGrant() throws {
+        let suiteName = "FileAccessGrantStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults.")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioMatorFileAccessGrant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        let fileAccessGrantStore = FileAccessGrantStore(userDefaults: defaults)
+        let grant = try fileAccessGrantStore.makeGrant(from: folderURL)
+        fileAccessGrantStore.saveGrants([grant])
+        let viewModel = makeViewModel(defaults: defaults)
+
+        viewModel.removeFileAccessGrant(id: UUID())
+
+        XCTAssertEqual(viewModel.fileAccessGrants.map(\.id), [grant.id])
+        XCTAssertEqual(
+            FileAccessGrantStore(userDefaults: defaults).loadGrants().map(\.id),
+            [grant.id]
+        )
+    }
+
+    private func makeViewModel(defaults: UserDefaults) -> AudioViewModel {
+        AudioViewModel(
+            watchedFolderStore: WatchedFolderStore(userDefaults: defaults),
+            fileAccessGrantStore: FileAccessGrantStore(userDefaults: defaults),
+            metadataPipeline: TagLibAudioMetadataPipeline(),
+            saveIssueLogStore: SaveIssueLogStore()
+        )
+    }
 }

--- a/AudioMatorTests/FileAccessGrantStoreTests.swift
+++ b/AudioMatorTests/FileAccessGrantStoreTests.swift
@@ -89,6 +89,40 @@ final class FileAccessGrantStoreTests: XCTestCase {
         )
     }
 
+    func testViewModelRemovesMultipleSelectedGrantsTogether() throws {
+        let suiteName = "FileAccessGrantStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults.")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let folderURLs = (0..<3).map { index in
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("AudioMatorFileAccessGrant-\(index)-\(UUID().uuidString)", isDirectory: true)
+        }
+        for folderURL in folderURLs {
+            try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        }
+        defer {
+            for folderURL in folderURLs {
+                try? FileManager.default.removeItem(at: folderURL)
+            }
+        }
+
+        let fileAccessGrantStore = FileAccessGrantStore(userDefaults: defaults)
+        let grants = try folderURLs.map(fileAccessGrantStore.makeGrant)
+        fileAccessGrantStore.saveGrants(grants)
+        let viewModel = makeViewModel(defaults: defaults)
+
+        viewModel.removeFileAccessGrants(ids: [grants[0].id, grants[2].id])
+
+        XCTAssertEqual(viewModel.fileAccessGrants.map(\.id), [grants[1].id])
+        XCTAssertEqual(
+            FileAccessGrantStore(userDefaults: defaults).loadGrants().map(\.id),
+            [grants[1].id]
+        )
+    }
+
     func testViewModelIgnoresRemovalOfUnknownGrant() throws {
         let suiteName = "FileAccessGrantStoreTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/AudioMatorTests/FileAccessGrantStoreTests.swift
+++ b/AudioMatorTests/FileAccessGrantStoreTests.swift
@@ -26,4 +26,33 @@ final class FileAccessGrantStoreTests: XCTestCase {
         XCTAssertEqual(restoredGrants.first?.id, grant.id)
         XCTAssertEqual(restoredGrants.first?.url.standardizedFileURL, folderURL.standardizedFileURL)
     }
+
+    func testSavingRemainingGrantsRemovesDeletedGrant() throws {
+        let suiteName = "FileAccessGrantStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults.")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let firstFolderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioMatorFileAccessGrant-\(UUID().uuidString)", isDirectory: true)
+        let secondFolderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioMatorFileAccessGrant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstFolderURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondFolderURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: firstFolderURL)
+            try? FileManager.default.removeItem(at: secondFolderURL)
+        }
+
+        let store = FileAccessGrantStore(userDefaults: defaults)
+        let firstGrant = try store.makeGrant(from: firstFolderURL)
+        let secondGrant = try store.makeGrant(from: secondFolderURL)
+        store.saveGrants([firstGrant, secondGrant])
+
+        store.saveGrants([secondGrant])
+
+        let restoredGrants = FileAccessGrantStore(userDefaults: defaults).loadGrants()
+        XCTAssertEqual(restoredGrants.map(\.id), [secondGrant.id])
+    }
 }

--- a/AudioMatorTests/WatchedFolderSettingsSelectionTests.swift
+++ b/AudioMatorTests/WatchedFolderSettingsSelectionTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import AudioMator
+
+#if os(macOS)
+final class WatchedFolderSettingsSelectionTests: XCTestCase {
+    func testSelectNewFoldersSelectsOnlyFoldersAddedByLatestEdit() {
+        let existingID = UUID()
+        let firstAddedID = UUID()
+        let secondAddedID = UUID()
+        var selection = WatchedFolderSettingsSelection(ids: [existingID])
+
+        selection.selectNewFolders(
+            previousIDs: [existingID],
+            currentIDs: [existingID, firstAddedID, secondAddedID]
+        )
+
+        XCTAssertEqual(selection.ids, [firstAddedID, secondAddedID])
+    }
+
+    func testRetainAvailableFoldersDropsSelectionsRemovedElsewhere() {
+        let retainedID = UUID()
+        let removedID = UUID()
+        var selection = WatchedFolderSettingsSelection(ids: [retainedID, removedID])
+
+        selection.retainAvailableFolders([retainedID])
+
+        XCTAssertEqual(selection.ids, [retainedID])
+    }
+
+    func testConsumeForRemovalReturnsAndClearsSelection() {
+        let firstID = UUID()
+        let secondID = UUID()
+        var selection = WatchedFolderSettingsSelection(ids: [firstID, secondID])
+
+        let removedIDs = selection.consumeForRemoval()
+
+        XCTAssertEqual(removedIDs, [firstID, secondID])
+        XCTAssertTrue(selection.ids.isEmpty)
+    }
+}
+#endif


### PR DESCRIPTION
This pull request introduces a new, dedicated File Access settings tab for managing authorized and watched folders on macOS. It refactors the settings UI to improve organization, consolidates interface-related settings, and adds batch operations for folder management. Several related ViewModel methods are updated to support these changes, and minor UI improvements are made elsewhere.

**Settings UI and Organization:**

* A new `FileAccessSettingsTab` is added for macOS, providing a dedicated interface for managing file access and watched folders, including adding/removing multiple folders at once and showing detailed information and error handling. (`AudioMator/Features/Settings/Views/FileAccessSettingsTab.swift`, [AudioMator/Features/Settings/Views/FileAccessSettingsTab.swiftR1-R389](diffhunk://#diff-c9fff5bdbb97043a9d06aa4b038385807d02e4cc2ac09b4a40e5451ec51fc80fR1-R389))
* The settings navigation is reorganized: the previous "Toolbar," "Columns," and "Inspector" tabs are consolidated into a single "Interface" tab, and the new "Folders" tab (for file access) is added for macOS. Selection logic is updated to migrate old tab selections to the new structure. (`AudioMator/Features/Settings/Views/SettingsView.swift`, [[1]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827L10-R13) [[2]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827R30) [[3]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827L51-R72) [[4]](diffhunk://#diff-1dd2a48cf48df085fb74c75c9d74097434245dd916ee063beda2cb834721b827L102-R103)

**Batch Folder Management:**

* The `AudioViewModel` gains new methods for batch removal of watched folders and file access grants, enabling multi-selection and removal from the new settings tab. The single-folder removal methods now delegate to these batch methods. (`AudioMator/Features/Main/ViewModels/AudioViewModel.swift`, [[1]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3L493-R507) [[2]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3L728-R784)

**UI/UX Improvements:**

* On macOS, the folder authorization dialog now supports selecting multiple folders at once, improving usability for users with many audio folders. (`AudioMator/Features/Main/ViewModels/AudioViewModel.swift`, [AudioMator/Features/Main/ViewModels/AudioViewModel.swiftL728-R784](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3L728-R784))
* The toolbar "Save Edits" button icon is changed from a download arrow to a checkmark for clarity. (`AudioMator/Features/Main/State/ToolbarButtonOption.swift`, [AudioMator/Features/Main/State/ToolbarButtonOption.swiftL58-R58](diffhunk://#diff-87bdb6d9c1b59aa576dc53621b4662e0edcfed8672b9f5eab93379150874e934L58-R58))

**Miscellaneous:**

* Minor code improvements, such as marking certain static methods as `nonisolated` for concurrency safety. (`AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzTaggingWorkbenchView.swift`, [AudioMator/Features/MusicBrainzBrowser/Views/MusicBrainzTaggingWorkbenchView.swiftL669-R675](diffhunk://#diff-965277ec506aa6434f84c4bb28ae1290ae58d3d636a47d8f1fa32a0b6bc19af5L669-R675))
* The `SettingsView` now receives the `viewModel` as a parameter to support the new tab. (`AudioMator/App/AudioMatorApp.swift`, [AudioMator/App/AudioMatorApp.swiftL78-R82](diffhunk://#diff-685970d64948f8b011c2f8fc5b2d957a29d1ffabb267bd4da3a57d1c870f9f0aL78-R82))

These changes collectively improve the organization, usability, and maintainability of the application's settings, especially for users managing multiple folders on macOS.