### PR TITLE
Isolate assignment list updates and guard refresh logic

### DIFF
--- a/AudioMator/Features/OnlineMetadataBrowser/Views/OnlineMetadataVirtualizedList.swift
+++ b/AudioMator/Features/OnlineMetadataBrowser/Views/OnlineMetadataVirtualizedList.swift
@@ -40,6 +40,7 @@ struct OnlineMetadataVirtualizedList<Row: Equatable>: NSViewRepresentable {
         }
 
         func update(parent: OnlineMetadataVirtualizedList, container: OnlineMetadataVirtualizedListContainer) {
+            container.totalConfigurationUpdateCount += 1
             let previousRows = renderedRows
             let previousIDs = previousRows.map(self.parent.rowID)
             let nextIDs = parent.rows.map(parent.rowID)
@@ -527,6 +528,7 @@ protocol OnlineMetadataVirtualizedListContainerDelegate: AnyObject {
 final class OnlineMetadataVirtualizedListContainer: NSView {
     weak var listDelegate: OnlineMetadataVirtualizedListContainerDelegate?
     fileprivate(set) var totalRowCount = 0
+    fileprivate(set) var totalConfigurationUpdateCount = 0
     fileprivate(set) var totalMaterializedRowBuildCount = 0
     fileprivate(set) var totalRowHeightMeasurementCount = 0
     private weak var observedClipView: NSClipView?

--- a/AudioMator/Features/iTunesBrowser/Views/iTunesTaggingWorkbenchView.swift
+++ b/AudioMator/Features/iTunesBrowser/Views/iTunesTaggingWorkbenchView.swift
@@ -136,47 +136,18 @@ struct iTunesTaggingWorkbenchView: View {
         .controlSize(.small)
     }
 
-    private var assignmentSection: some View {
-        MetadataSectionCard(
-            title: "Assignments",
-            symbolName: "link",
-            lazyContent: {
-                #if os(macOS)
-                false
-                #else
-                true
-                #endif
-            }()
-        ) {
-            #if os(macOS)
-            iTunesAssignmentsAppKitList(
-                assignments: store.assignments,
-                tracks: store.availableTracks,
-                isApplying: isApplying,
-                selectedTrackID: { store.selectedTrackID(for: $0.id) },
-                selectedTrack: { store.track(for: $0) },
-                isDuplicate: { store.isDuplicateAssignment($0) },
-                onSelectTrack: { trackID, assignmentID in
-                    store.updateSelectedTrack(trackID, for: assignmentID)
-                }
-            )
-            #else
-            ForEach(Array(store.assignments.enumerated()), id: \.element.id) { index, assignment in
-                iTunesAssignmentRow(
-                    assignment: assignment,
-                    tracks: store.availableTracks,
-                    isDuplicate: store.isDuplicateAssignment(assignment),
-                    selection: trackSelectionBinding(for: assignment),
-                    selectedTrack: store.track(for: assignment)
-                )
-                .disabled(isApplying)
-
-                if index < store.assignments.count - 1 {
-                    MetadataCardDivider()
-                }
+    var assignmentSection: some View {
+        iTunesAssignmentSection(
+            storeID: store.id,
+            assignments: store.assignments,
+            tracks: store.availableTracks,
+            duplicateTrackIDs: store.duplicateTrackIDs,
+            isApplying: isApplying,
+            onSelectTrack: { trackID, assignmentID in
+                store.updateSelectedTrack(trackID, for: assignmentID)
             }
-            #endif
-        }
+        )
+        .equatable()
     }
 
     private func diffSection(plan: iTunesTaggingPlan) -> some View {
@@ -251,13 +222,6 @@ struct iTunesTaggingWorkbenchView: View {
         )
     }
 
-    private func trackSelectionBinding(for assignment: iTunesTaggingWorkbenchStore.AssignmentDraft) -> Binding<Int?> {
-        Binding(
-            get: { store.selectedTrackID(for: assignment.id) },
-            set: { store.updateSelectedTrack($0, for: assignment.id) }
-        )
-    }
-
     private func applyTags(plan: iTunesTaggingPlan) {
         let entries = plan.writeEntries
         guard !entries.isEmpty, viewModel.metadataSaveProgress == nil else { return }
@@ -272,6 +236,73 @@ struct iTunesTaggingWorkbenchView: View {
             await viewModel.applyiTunesTaggingPlan(entries)
             guard !Task.isCancelled else { return }
             store.refreshLoadedFiles(viewModel.files)
+        }
+    }
+}
+
+struct iTunesAssignmentSection: View, Equatable {
+    let storeID: UUID
+    let assignments: [iTunesTaggingWorkbenchStore.AssignmentDraft]
+    let tracks: [iTunesTrackResult]
+    let duplicateTrackIDs: Set<Int>
+    let isApplying: Bool
+    let onSelectTrack: (Int?, String) -> Void
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.storeID == rhs.storeID &&
+            lhs.assignments == rhs.assignments &&
+            lhs.tracks == rhs.tracks &&
+            lhs.duplicateTrackIDs == rhs.duplicateTrackIDs &&
+            lhs.isApplying == rhs.isApplying
+    }
+
+    var body: some View {
+        let tracksByID = Dictionary(uniqueKeysWithValues: tracks.map { ($0.trackID, $0) })
+
+        MetadataSectionCard(
+            title: "Assignments",
+            symbolName: "link",
+            lazyContent: {
+                #if os(macOS)
+                false
+                #else
+                true
+                #endif
+            }()
+        ) {
+            #if os(macOS)
+            iTunesAssignmentsAppKitList(
+                assignments: assignments,
+                tracks: tracks,
+                isApplying: isApplying,
+                selectedTrackID: { $0.selectedTrackID },
+                selectedTrack: { assignment in
+                    assignment.selectedTrackID.flatMap { tracksByID[$0] }
+                },
+                isDuplicate: { assignment in
+                    assignment.selectedTrackID.map(duplicateTrackIDs.contains) ?? false
+                },
+                onSelectTrack: onSelectTrack
+            )
+            #else
+            ForEach(Array(assignments.enumerated()), id: \.element.id) { index, assignment in
+                iTunesAssignmentRow(
+                    assignment: assignment,
+                    tracks: tracks,
+                    isDuplicate: assignment.selectedTrackID.map(duplicateTrackIDs.contains) ?? false,
+                    selection: Binding(
+                        get: { assignment.selectedTrackID },
+                        set: { onSelectTrack($0, assignment.id) }
+                    ),
+                    selectedTrack: assignment.selectedTrackID.flatMap { tracksByID[$0] }
+                )
+                .disabled(isApplying)
+
+                if index < assignments.count - 1 {
+                    MetadataCardDivider()
+                }
+            }
+            #endif
         }
     }
 }

--- a/AudioMatorTests/OnlineMetadataWorkbenchPerformanceTests.swift
+++ b/AudioMatorTests/OnlineMetadataWorkbenchPerformanceTests.swift
@@ -126,13 +126,18 @@ final class OnlineMetadataWorkbenchPerformanceTests: XCTestCase {
         musicBrainzStore.cancelPendingRecordingLoads()
 
         let iTunesStore = makeiTunesStore(scenario: scenario)
-        let iTunesBody = iTunesTaggingWorkbenchView(
+        let iTunesView = iTunesTaggingWorkbenchView(
             store: iTunesStore,
             viewModel: viewModel
-        ).body
+        )
+        let iTunesBody = iTunesView.body
         XCTAssertFalse(
             containsLazyVStack(in: iTunesBody),
             "The page-level section container must stay eager so row-level lazy stacks do not enter a layout-estimation cycle."
+        )
+        XCTAssertTrue(
+            String(reflecting: type(of: iTunesView.assignmentSection)).contains("EquatableView"),
+            "iTunes assignments must stay behind an equatable boundary so field and plan publications cannot invalidate their native list while the user scrolls."
         )
     }
 

--- a/AudioMatorTests/OnlineMetadataWorkbenchPerformanceTests.swift
+++ b/AudioMatorTests/OnlineMetadataWorkbenchPerformanceTests.swift
@@ -230,6 +230,56 @@ final class OnlineMetadataWorkbenchPerformanceTests: XCTestCase {
         )
     }
 
+    func testiTunesFieldChangesDoNotInvalidateNativeAssignments() async throws {
+        let scenario = OnlineMetadataWorkbenchPerformanceScenarioFactory.make(trackCount: 50)
+        let viewModel = makeViewModel(files: scenario.files)
+        let store = makeiTunesStore(scenario: scenario)
+        let hosted = HostedWorkbench(
+            rootView: iTunesTaggingWorkbenchView(store: store, viewModel: viewModel)
+        )
+
+        try await hosted.stabilizeAsync()
+        try await hosted.scrollDownAsync(distance: 1_000)
+        try await hosted.stabilizeAsync()
+
+        let list = try XCTUnwrap(
+            hosted.descendants(of: OnlineMetadataVirtualizedListContainer.self).first
+        )
+        let configurationCount = list.totalConfigurationUpdateCount
+        let field = try XCTUnwrap(iTunesTagWriteField.allCases.first)
+
+        store.setFieldSelected(!store.isFieldSelected(field), for: field)
+        try await hosted.stabilizeAsync()
+
+        let listAfterFieldChange = try XCTUnwrap(
+            hosted.descendants(of: OnlineMetadataVirtualizedListContainer.self).first
+        )
+        XCTAssertTrue(listAfterFieldChange === list)
+        XCTAssertEqual(
+            listAfterFieldChange.totalConfigurationUpdateCount,
+            configurationCount,
+            "Field and plan publications must not reconfigure an unchanged native assignment list."
+        )
+
+        let assignment = try XCTUnwrap(store.assignments.first)
+        let replacementTrackID = assignment.selectedTrackID == nil
+            ? store.availableTracks.first?.trackID
+            : nil
+        store.updateSelectedTrack(replacementTrackID, for: assignment.id)
+        try await hosted.stabilizeAsync()
+
+        let listAfterAssignmentChange = try XCTUnwrap(
+            hosted.descendants(of: OnlineMetadataVirtualizedListContainer.self).first
+        )
+        XCTAssertTrue(listAfterAssignmentChange === list)
+        XCTAssertGreaterThan(
+            listAfterAssignmentChange.totalConfigurationUpdateCount,
+            configurationCount,
+            "A real assignment change must still update the native list."
+        )
+        hosted.tearDown()
+    }
+
     func testSelectAllThenPreDiffScrollUsesWarmMedianSamples() async throws {
         let scenario = OnlineMetadataWorkbenchPerformanceScenarioFactory.make(
             trackCount: 21,


### PR DESCRIPTION
This pull request makes significant improvements to the `iTunesTaggingWorkbenchView` and its assignment section, focusing on better separation of concerns, improved testability, and performance optimizations for list rendering. The main change is the extraction of the assignment section into a new, equatable view, which ensures that only relevant state changes trigger UI updates. Additional performance tracking and testing have also been added to ensure these optimizations are effective.

**Assignment Section Refactoring and Optimization:**

* Extracted the assignment section UI logic from `iTunesTaggingWorkbenchView` into a new, standalone `iTunesAssignmentSection` struct, which is `Equatable`. This ensures that only changes to assignments, tracks, or related state will trigger re-renders of the assignment list, preventing unnecessary UI invalidations from unrelated state changes. [[1]](diffhunk://#diff-1ed3068a15b61fc9a47b9792df3f88762a32191f13a10872f811b1c0f28b2d63L139-R150) [[2]](diffhunk://#diff-1ed3068a15b61fc9a47b9792df3f88762a32191f13a10872f811b1c0f28b2d63R243-R309)
* Updated the assignment section to use `.equatable()` and removed platform-specific branching from the parent view, further simplifying the code and improving maintainability.

**Performance Tracking and Testing:**

* Added a new property `totalConfigurationUpdateCount` to `OnlineMetadataVirtualizedListContainer` and incremented it on each configuration update, enabling fine-grained tracking of list reconfigurations for performance testing. [[1]](diffhunk://#diff-121dad323f5ec78a4c76e4f3245f4aed4275ab5e194abb785b78fef4e53a4554R43) [[2]](diffhunk://#diff-121dad323f5ec78a4c76e4f3245f4aed4275ab5e194abb785b78fef4e53a4554R531)
* Enhanced performance tests in `OnlineMetadataWorkbenchPerformanceTests` to assert that field and plan changes do not invalidate the native assignment list, while real assignment changes do. This ensures that the new equatable boundary is working as intended. [[1]](diffhunk://#diff-c8fe163dfaa96fdab47a714a8a7aeea6fd8c983464a682d2c5b0db0eccc631d6L129-R141) [[2]](diffhunk://#diff-c8fe163dfaa96fdab47a714a8a7aeea6fd8c983464a682d2c5b0db0eccc631d6R233-R282)

**Codebase Clean-up:**

* Removed the now-unnecessary `trackSelectionBinding(for:)` helper from `iTunesTaggingWorkbenchView`, as selection logic is now encapsulated within the new assignment section.

These changes together improve the architecture, maintainability, and performance of the assignment section in the iTunes tagging workbench.