### PR TITLE
Improve transient read handling

### DIFF
--- a/AudioMator.xcodeproj/project.pbxproj
+++ b/AudioMator.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 			repositoryURL = "https://github.com/ChrisLloydME/TagLibAudioMetadata.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.4;
+				minimumVersion = 0.4.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioMator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AudioMator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChrisLloydME/TagLibAudioMetadata.git",
       "state" : {
-        "revision" : "8b544efa457b1cf2603ff6dcaedb20b2fb08eb76",
-        "version" : "0.4.4"
+        "revision" : "107e7d7b1a4148fe4b3aa9845a296b4934b1a790",
+        "version" : "0.4.5"
       }
     }
   ],

--- a/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
+++ b/AudioMator/Features/Main/ViewModels/AudioViewModel.swift
@@ -555,6 +555,7 @@ final class AudioViewModel: ObservableObject {
                 from: candidateURLs,
                 fileIDsByKey: context.fileIDsByKey,
                 metadataPipeline: context.metadataPipeline,
+                retryTransientFailures: true,
                 onBatchLoaded: { [weak self] batch in
                     guard !batch.isEmpty, !Task.isCancelled else { return }
                     await MainActor.run { [weak self] in
@@ -1208,6 +1209,7 @@ final class AudioViewModel: ObservableObject {
         from urls: [URL],
         fileIDsByKey: [String: UUID],
         metadataPipeline: any AudioMetadataPipeline,
+        retryTransientFailures: Bool = false,
         onBatchLoaded: (@Sendable ([AudioFile]) async -> Void)? = nil
     ) async -> AudioFileLoadResult {
         let inputs: [(index: Int, url: URL, id: UUID)] = urls.enumerated().compactMap { offset, url in
@@ -1244,7 +1246,12 @@ final class AudioViewModel: ObservableObject {
                 group.addTask {
                     guard !Task.isCancelled else { return (input.index, input.url, nil, nil) }
                     do {
-                        let file = try await metadataPipeline.loadAudioFile(at: input.url, id: input.id)
+                        let file = try await loadAudioFile(
+                            at: input.url,
+                            id: input.id,
+                            metadataPipeline: metadataPipeline,
+                            retryTransientFailures: retryTransientFailures
+                        )
                         return (
                             input.index,
                             input.url,
@@ -1310,7 +1317,12 @@ final class AudioViewModel: ObservableObject {
                 group.addTask {
                     guard !Task.isCancelled else { return (input.index, input.url, nil, nil) }
                     do {
-                        let file = try await metadataPipeline.loadAudioFile(at: input.url, id: input.id)
+                        let file = try await loadAudioFile(
+                            at: input.url,
+                            id: input.id,
+                            metadataPipeline: metadataPipeline,
+                            retryTransientFailures: retryTransientFailures
+                        )
                         return (
                             input.index,
                             input.url,
@@ -1336,6 +1348,28 @@ final class AudioViewModel: ObservableObject {
             files: loadedByIndex.map(\.1),
             failures: failuresByIndex.map(\.1)
         )
+    }
+
+    nonisolated private static func loadAudioFile(
+        at url: URL,
+        id: UUID,
+        metadataPipeline: any AudioMetadataPipeline,
+        retryTransientFailures: Bool
+    ) async throws -> AudioFile {
+        do {
+            return try await metadataPipeline.loadAudioFile(at: url, id: id)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            guard retryTransientFailures, !Task.isCancelled else { throw error }
+
+            // A newly selected security-scoped or file-provider URL can be briefly
+            // unavailable while macOS grants access or materializes its contents.
+            // Keep the scope alive and retry the read once instead of requiring the
+            // user to select the same file again.
+            try await Task.sleep(for: .milliseconds(200))
+            return try await metadataPipeline.loadAudioFile(at: url, id: id)
+        }
     }
 
     nonisolated private static func scanFolderSnapshot(for folderURL: URL) -> FolderScanSnapshot {

--- a/AudioMatorTests/QuickImportCancellationTests.swift
+++ b/AudioMatorTests/QuickImportCancellationTests.swift
@@ -140,6 +140,21 @@ final class QuickImportCancellationTests: XCTestCase {
         )
     }
 
+    func testQuickImportRetriesTransientInitialReadFailure() async throws {
+        let fileURL = URL(fileURLWithPath: "/tmp/transient-first-read-failure.mp3")
+        let control = TransientQuickImportReadControl()
+        let pipeline = TransientlyFailingQuickImportMetadataPipeline(control: control)
+        let viewModel = AudioViewModel(metadataPipeline: pipeline)
+
+        viewModel.importQuickFiles(from: [fileURL])
+        try await waitUntil(viewModel.activeQuickImportTaskCount == 0)
+        let attemptCount = await control.attemptCount
+
+        XCTAssertEqual(viewModel.files.map(\.url), [fileURL])
+        XCTAssertEqual(attemptCount, 2)
+        XCTAssertNil(viewModel.metadataWriteHUD)
+    }
+
     func testWatchedFolderRefreshRetainsLastKnownFileWhenMetadataReadFails() async throws {
         let suiteName = "AudioMator.WatchedFolderReadFailureTests.\(UUID().uuidString)"
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -366,6 +381,51 @@ private final class PartiallyFailingQuickImportMetadataPipeline: AudioMetadataPi
     nonisolated func loadAudioFile(at url: URL, id: UUID) async throws -> AudioFile {
         if url == unreadableURL {
             throw CocoaError(.fileReadNoPermission)
+        }
+        return await AudioFileTestFactory.make(id: id, url: url)
+    }
+
+    nonisolated func rawMetadataDumpText(for url: URL) -> String? { nil }
+    nonisolated func rawMetadataPropertyMap(for url: URL) throws -> [String: String] { [:] }
+    nonisolated func writeMetadata(_ edit: MetadataEditPayload, to url: URL) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+    nonisolated func writeRawMetadataPropertyMap(_ propertyMap: [String: String], to url: URL) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+    nonisolated func eraseAllMetadata(at url: URL) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+    nonisolated func writeTrackNumberText(
+        _ trackNumberText: String,
+        discNumberText: String?,
+        to url: URL,
+        verifyAfterWrite: Bool
+    ) throws -> AudioMetadataWriteResult {
+        AudioMetadataWriteResult(warnings: [])
+    }
+}
+
+private actor TransientQuickImportReadControl {
+    private(set) var attemptCount = 0
+
+    func recordAttempt() -> Int {
+        attemptCount += 1
+        return attemptCount
+    }
+}
+
+private final class TransientlyFailingQuickImportMetadataPipeline: AudioMetadataPipeline, @unchecked Sendable {
+    private let control: TransientQuickImportReadControl
+
+    init(control: TransientQuickImportReadControl) {
+        self.control = control
+    }
+
+    nonisolated func loadAudioFile(at url: URL, id: UUID) async throws -> AudioFile {
+        let attempt = await control.recordAttempt()
+        guard attempt > 1 else {
+            throw CocoaError(.fileReadUnknown)
         }
         return await AudioFileTestFactory.make(id: id, url: url)
     }

--- a/AudioMatorTests/QuickImportCancellationTests.swift
+++ b/AudioMatorTests/QuickImportCancellationTests.swift
@@ -148,7 +148,7 @@ final class QuickImportCancellationTests: XCTestCase {
 
         viewModel.importQuickFiles(from: [fileURL])
         try await waitUntil(viewModel.activeQuickImportTaskCount == 0)
-        let attemptCount = await control.attemptCount
+        let attemptCount = await control.attemptCount(for: fileURL)
 
         XCTAssertEqual(viewModel.files.map(\.url), [fileURL])
         XCTAssertEqual(attemptCount, 2)
@@ -407,11 +407,15 @@ private final class PartiallyFailingQuickImportMetadataPipeline: AudioMetadataPi
 }
 
 private actor TransientQuickImportReadControl {
-    private(set) var attemptCount = 0
+    private var attemptCountsByURL: [URL: Int] = [:]
 
-    func recordAttempt() -> Int {
-        attemptCount += 1
-        return attemptCount
+    func recordAttempt(for url: URL) -> Int {
+        attemptCountsByURL[url, default: 0] += 1
+        return attemptCountsByURL[url, default: 0]
+    }
+
+    func attemptCount(for url: URL) -> Int {
+        attemptCountsByURL[url, default: 0]
     }
 }
 
@@ -423,7 +427,7 @@ private final class TransientlyFailingQuickImportMetadataPipeline: AudioMetadata
     }
 
     nonisolated func loadAudioFile(at url: URL, id: UUID) async throws -> AudioFile {
-        let attempt = await control.recordAttempt()
+        let attempt = await control.recordAttempt(for: url)
         guard attempt > 1 else {
             throw CocoaError(.fileReadUnknown)
         }

--- a/AudioMatorTests/TagLibReadWriteIntegrationTests.swift
+++ b/AudioMatorTests/TagLibReadWriteIntegrationTests.swift
@@ -70,6 +70,36 @@ final class TagLibReadWriteIntegrationTests: XCTestCase {
         }
     }
 
+    func testConcurrentM4AReadsRemainStable() async throws {
+        let fixtureURL = try bundledAudioFixtureURL(named: "testAudioFile.m4a")
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioMator-Concurrent-M4A-Reads-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+
+        let fixtureURLs = try (0..<12).map { index in
+            let copyURL = temporaryDirectory.appendingPathComponent("fixture-\(index).m4a")
+            try FileManager.default.copyItem(at: fixtureURL, to: copyURL)
+            return copyURL
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for fixtureURL in fixtureURLs {
+                group.addTask {
+                    for _ in 0..<25 {
+                        let metadata = try TagLibMetadataManager.readMetadataResult(from: fixtureURL)
+                        guard metadata.duration > 0 else {
+                            throw ConcurrentM4AReadTestError.missingDuration(fixtureURL)
+                        }
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
     func testRawMetadataInspectionLoadsAcrossAudioFixtures() throws {
         let pipeline = TagLibAudioMetadataPipeline()
 
@@ -688,4 +718,8 @@ final class TagLibReadWriteIntegrationTests: XCTestCase {
     private func removeTemporaryFixtureDirectory(containing workingURL: URL) {
         try? FileManager.default.removeItem(at: workingURL.deletingLastPathComponent())
     }
+}
+
+private enum ConcurrentM4AReadTestError: Error {
+    case missingDuration(URL)
 }


### PR DESCRIPTION
This pull request introduces improvements to audio file loading reliability and test coverage, as well as updates a dependency version. The most significant change is the addition of a retry mechanism for transient read failures when importing audio files, which enhances user experience by reducing the likelihood of failed imports due to temporary file access issues. The pull request also adds new tests to ensure the robustness of this retry logic and to verify stability in concurrent audio file reads.

**Audio file loading reliability:**

* Added a retry mechanism for transient failures when loading audio files by introducing a `retryTransientFailures` parameter and a helper method `loadAudioFile` in `AudioViewModel`. This allows a failed read to be retried once after a short delay, improving resilience to temporary file access issues. [[1]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3R558) [[2]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3R1212) [[3]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3L1247-R1254) [[4]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3L1313-R1325) [[5]](diffhunk://#diff-496edd99dd985a558a5b6b482bc33e523398456fa468a5682010f283d04868f3R1353-R1374)

**Testing improvements:**

* Added a unit test (`testQuickImportRetriesTransientInitialReadFailure`) and supporting test infrastructure to verify that transient initial read failures are retried during quick import. [[1]](diffhunk://#diff-1a43f06da41248ee6f3d3e7066709fb1c202709ae522869c3dbbe14faa9a7c13R143-R157) [[2]](diffhunk://#diff-1a43f06da41248ee6f3d3e7066709fb1c202709ae522869c3dbbe14faa9a7c13R409-R457)
* Added an integration test (`testConcurrentM4AReadsRemainStable`) to ensure concurrent reads of M4A files remain stable, along with a supporting error type. [[1]](diffhunk://#diff-6e7aea8fb220c39cd7b02c8a047efd92957f6d5eb54caf90203ad06dc999603cR73-R102) [[2]](diffhunk://#diff-6e7aea8fb220c39cd7b02c8a047efd92957f6d5eb54caf90203ad06dc999603cR722-R725)

**Dependency updates:**

* Updated the `TagLibAudioMetadata` Swift package dependency from version 0.4.4 to 0.4.5 in both the Xcode project and `Package.resolved`. [[1]](diffhunk://#diff-ff0d7aa6d7efc513c83271c3b18936064ed314840ed7fec55ae170d9682dbd5eL593-R593) [[2]](diffhunk://#diff-ae9eaeae07e7bdf39358b2304fbf39eaacf486deec001362ffec810c23c20ca6L18-R19)