### PR TITLE
Fix seeded search handling and multi-file request overflow

### DIFF
--- a/AudioMator/Features/MusicBrainzBrowser/ViewModels/MusicBrainzBrowserStore.swift
+++ b/AudioMator/Features/MusicBrainzBrowser/ViewModels/MusicBrainzBrowserStore.swift
@@ -252,6 +252,9 @@ final class MusicBrainzBrowserStore: ObservableObject {
 
     func handleModeChange(from oldMode: MusicBrainzSearchMode, to newMode: MusicBrainzSearchMode) {
         guard oldMode != newMode else { return }
+        // Seeding can update the mode and immediately start a search before SwiftUI
+        // delivers its deferred onChange notification. Do not cancel that search.
+        guard lastSubmittedQuery?.mode != newMode else { return }
         cancelSearch()
         resetNavigation()
         isSearching = false

--- a/AudioMator/Infrastructure/MusicBrainz/MusicBrainzClient.swift
+++ b/AudioMator/Infrastructure/MusicBrainz/MusicBrainzClient.swift
@@ -40,6 +40,7 @@ nonisolated protocol MusicBrainzBrowserClient: Sendable {
 
 nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
     private static let baseURL = URL(string: "https://\(NetworkServiceDisclosure.MusicBrainz.host)/ws/2")!
+    private static let multiFileFallbackQueryLimit = 3
 
     private let session: URLSession
     private let decoder: JSONDecoder
@@ -141,17 +142,30 @@ nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
 
         let strongQueries = MusicBrainzLuceneQueryBuilder.fileClusterStrongReleaseSearchQueries(from: query)
         if !strongQueries.isEmpty {
-            candidates.append(contentsOf: try await searchReleases(luceneQueries: strongQueries, limit: 12))
+            candidates.append(contentsOf: try await searchReleases(
+                luceneQueries: Array(strongQueries.prefix(Self.multiFileFallbackQueryLimit)),
+                limit: 12
+            ))
         }
 
-        let broadQueries = MusicBrainzLuceneQueryBuilder.fileClusterBroadReleaseSearchQueries(from: query)
-        if !broadQueries.isEmpty {
-            candidates.append(contentsOf: try await searchReleases(luceneQueries: broadQueries, limit: 20))
+        if candidates.isEmpty {
+            let broadQueries = MusicBrainzLuceneQueryBuilder.fileClusterBroadReleaseSearchQueries(from: query)
+            if !broadQueries.isEmpty {
+                candidates.append(contentsOf: try await searchReleases(
+                    luceneQueries: Array(broadQueries.prefix(Self.multiFileFallbackQueryLimit)),
+                    limit: 20
+                ))
+            }
         }
 
-        for candidate in try await releaseCandidatesFromRepresentativeFiles(selectionSummary, filters: query.releaseFilters) {
-            candidates.append(candidate.release)
-            filenameEvidenceByReleaseID[candidate.release.id, default: 0] += candidate.evidence
+        if candidates.isEmpty {
+            for candidate in try await releaseCandidatesFromRepresentativeFiles(
+                selectionSummary,
+                filters: query.releaseFilters
+            ) {
+                candidates.append(candidate.release)
+                filenameEvidenceByReleaseID[candidate.release.id, default: 0] += candidate.evidence
+            }
         }
 
         let deduplicatedCandidates = Self.deduplicatedReleases(candidates)
@@ -231,7 +245,9 @@ nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
 
         var evidenceByReleaseID: [String: Double] = [:]
 
-        for (fileIndex, file) in representativeFiles.enumerated() {
+        // One representative recording is enough to discover release IDs. The
+        // full selection is compared against release details later in the flow.
+        for (fileIndex, file) in representativeFiles.prefix(1).enumerated() {
             try Task.checkCancellation()
             let title = file.title.isEmpty ? file.preferredDisplayTitle : file.title
             guard !title.isEmpty else { continue }
@@ -255,7 +271,11 @@ nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
                 releaseFilters: filters
             )
 
-            let recordings = try await searchFiles(matching: query, limit: 6)
+            let recordings = try await searchFiles(
+                matching: query,
+                limit: 6,
+                fallbackQueryLimit: Self.multiFileFallbackQueryLimit
+            )
             let fileWeight = max(0.45, 1.0 - (Double(fileIndex) * 0.2))
 
             for (recordingIndex, recording) in recordings.prefix(4).enumerated() {
@@ -295,7 +315,11 @@ nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
         return candidates
     }
 
-    func searchFiles(matching query: MusicBrainzSearchQuery, limit: Int = 50) async throws -> [MusicBrainzRecordingResult] {
+    func searchFiles(
+        matching query: MusicBrainzSearchQuery,
+        limit: Int = 50,
+        fallbackQueryLimit: Int? = nil
+    ) async throws -> [MusicBrainzRecordingResult] {
         guard !query.isEmpty else {
             throw MusicBrainzClientError.emptyQuery
         }
@@ -303,14 +327,20 @@ nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
         var candidates: [MusicBrainzRecordingResult] = []
         var preferredRecordingIDs: Set<String> = []
 
-        let strongQueries = MusicBrainzLuceneQueryBuilder.fileStrongSearchQueries(from: query)
+        let strongQueries = Self.limitedQueries(
+            MusicBrainzLuceneQueryBuilder.fileStrongSearchQueries(from: query),
+            maximumCount: fallbackQueryLimit
+        )
         if !strongQueries.isEmpty {
             let exactMatches = try await searchRecordings(luceneQueries: strongQueries, limit: 15)
             candidates.append(contentsOf: exactMatches)
             preferredRecordingIDs.formUnion(exactMatches.map(\.id))
         }
 
-        let broadQueries = MusicBrainzLuceneQueryBuilder.fileSearchQueries(from: query)
+        let broadQueries = Self.limitedQueries(
+            MusicBrainzLuceneQueryBuilder.fileSearchQueries(from: query),
+            maximumCount: fallbackQueryLimit
+        )
         if !broadQueries.isEmpty {
             candidates.append(contentsOf: try await searchRecordings(luceneQueries: broadQueries, limit: limit))
         }
@@ -556,6 +586,11 @@ nonisolated struct MusicBrainzClient: MusicBrainzBrowserClient, Sendable {
         }
 
         return orderedResults
+    }
+
+    private static func limitedQueries(_ queries: [String], maximumCount: Int?) -> [String] {
+        guard let maximumCount else { return queries }
+        return Array(queries.prefix(max(0, maximumCount)))
     }
 
     private static func deduplicatedReleases(_ releases: [MusicBrainzReleaseSearchResult]) -> [MusicBrainzReleaseSearchResult] {

--- a/AudioMatorTests/ProviderNetworkFaultTests.swift
+++ b/AudioMatorTests/ProviderNetworkFaultTests.swift
@@ -182,6 +182,52 @@ final class ProviderNetworkFaultTests: XCTestCase {
         XCTAssertTrue(requestRecorder.timeoutIntervals.allSatisfy { $0 == 15 })
     }
 
+    func testMusicBrainzMultiFileNoResultSearchHasBoundedFallbackRequests() async throws {
+        let requestRecorder = ProviderRequestRecorder()
+        ProviderFaultURLProtocol.requestHandler = { request in
+            requestRecorder.record(request)
+            let data = request.url?.path.contains("/release") == true
+                ? Data(#"{"releases":[]}"#.utf8)
+                : Data(#"{"recordings":[]}"#.utf8)
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            return (response, data)
+        }
+        let files = (1...3).map { trackNumber in
+            MusicBrainzFileSearchInput(
+                id: "file-\(trackNumber)",
+                displayTitle: "Track \(trackNumber)",
+                title: "Track \(trackNumber)",
+                artist: "Artist",
+                albumArtist: "Artist",
+                album: "Album",
+                trackNumber: String(trackNumber),
+                trackTotal: 3,
+                durationMilliseconds: 180_000
+            )
+        }
+        let query = MusicBrainzSearchQuery(mode: .file, fileInputs: files)
+        let client = MusicBrainzClient(
+            session: makeSession(),
+            rateLimiter: MusicBrainzRateLimiter(minimumIntervalNanoseconds: 0)
+        )
+
+        let results = try await client.search(matching: query, limit: 25)
+
+        XCTAssertEqual(results, .releases([]))
+        XCTAssertLessThanOrEqual(
+            requestRecorder.requestCount,
+            9,
+            "A no-result fallback must stay below the browser's overall search deadline."
+        )
+    }
+
     func testArtworkNormalizerDownsamplesBeforePNGEncoding() throws {
         let sourceData = try XCTUnwrap(
             Data(
@@ -388,6 +434,10 @@ private final class ProviderRequestRecorder: @unchecked Sendable {
 
     var hosts: [String] {
         lock.withLock { recordedRequests.compactMap(\.host) }
+    }
+
+    var requestCount: Int {
+        lock.withLock { recordedRequests.count }
     }
 
     func record(_ request: URLRequest) {

--- a/AudioMatorTests/ProviderSearchRestartTests.swift
+++ b/AudioMatorTests/ProviderSearchRestartTests.swift
@@ -4,6 +4,40 @@ import XCTest
 #if os(macOS)
 @MainActor
 final class ProviderSearchRestartTests: XCTestCase {
+    func testMusicBrainzSeededModeNotificationDoesNotCancelInitialSearch() {
+        let gate = NonCooperativeProviderSearchGate()
+        let store = MusicBrainzBrowserStore(
+            client: NonCooperativeMusicBrainzBrowserClient(gate: gate)
+        )
+        store.apply(seed: MusicBrainzSearchSeed(
+            mode: .file,
+            title: "Track",
+            artist: "Artist",
+            albumArtist: "Artist",
+            album: "Album",
+            trackNumber: "1",
+            trackTotal: 1,
+            durationMilliseconds: 180_000,
+            releaseDate: "",
+            isrc: "",
+            barcode: "",
+            musicBrainzAlbumID: "",
+            musicBrainzTrackID: "",
+            fileInputs: [],
+            link: "",
+            sourceDescription: "Test selection"
+        ))
+
+        store.search()
+        store.handleModeChange(from: .track, to: .file)
+
+        XCTAssertTrue(
+            store.isSearching,
+            "The deferred mode notification from seeding must not cancel the initial search."
+        )
+        store.closeWindowSession()
+    }
+
     func testiTunesAlbumMatchingDoesNotBlockMainActor() async throws {
         let matchingGate = BlockingSynchronousGate()
         let detail = makeAlbumDetail()


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the MusicBrainz search logic, focusing on bounding fallback searches, improving efficiency, and ensuring correct UI behavior when seeding searches. Additionally, new tests are added to verify these behaviors.

**MusicBrainz Search Logic Improvements:**

* Limited the number of fallback Lucene queries used during multi-file release and recording searches to a maximum of three, preventing excessive network requests when no results are found. [[1]](diffhunk://#diff-91752021b6110e525fd49501af4b7e662a7e8f5b21a9b03a78cd535c32f42ac6R43) [[2]](diffhunk://#diff-91752021b6110e525fd49501af4b7e662a7e8f5b21a9b03a78cd535c32f42ac6L144-R169) [[3]](diffhunk://#diff-91752021b6110e525fd49501af4b7e662a7e8f5b21a9b03a78cd535c32f42ac6L258-R278) [[4]](diffhunk://#diff-91752021b6110e525fd49501af4b7e662a7e8f5b21a9b03a78cd535c32f42ac6L298-R343) [[5]](diffhunk://#diff-91752021b6110e525fd49501af4b7e662a7e8f5b21a9b03a78cd535c32f42ac6R591-R595)
* Optimized representative file search by only using the first representative file to discover release IDs, improving performance.

**UI Behavior Fixes:**

* Updated `MusicBrainzBrowserStore` so that a deferred mode change notification triggered by seeding does not cancel an in-progress search, ensuring the initial search is not interrupted.

**Testing Improvements:**

* Added a test to verify that fallback searches for multi-file queries are bounded and do not exceed the browser's search deadline. [[1]](diffhunk://#diff-ceff00c4b02917d7f2eef0a6acfc715ba87a24f154eaadf3bd4445a48bb1e784R185-R230) [[2]](diffhunk://#diff-ceff00c4b02917d7f2eef0a6acfc715ba87a24f154eaadf3bd4445a48bb1e784R439-R442)
* Added a test to ensure that seeding the MusicBrainz browser does not cancel the initial search due to a deferred mode notification.